### PR TITLE
'Backport' instead of 'Backports' as the repository is named

### DIFF
--- a/usr/share/mintsources/olivia/mintsources.conf
+++ b/usr/share/mintsources/olivia/mintsources.conf
@@ -11,7 +11,7 @@ base_mirrors=/usr/share/python-apt/templates/Ubuntu.mirrors
 
 [optional_component_1]
 name=backport
-description=Backported packages (backports)
+description=Backported packages (backport)
 
 [optional_component_2]
 name=romeo


### PR DESCRIPTION
'Backport' instead of 'Backports' as the repository is named
