### PR TITLE
Do not list mirrors.txt and the TU Chemnitz ubuntu-ports mirror

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -587,29 +587,8 @@ class Application(object):
                 nb_components += 1   
 
 
-        self.mirrors = []
-        mirrorsfile = open(self.config["mirrors"]["mirrors"], "r")
-        for line in mirrorsfile.readlines():
-            line = line.strip()
-            if line != "":
-                if ("#LOC:" in line):
-                    country_code = line.split(":")[1]
-                else:
-                    if country_code is not None:
-                        mirror = Mirror(line, country_code)
-                        self.mirrors.append(mirror)
-
-        self.base_mirrors = []
-        mirrorsfile = open(self.config["mirrors"]["base_mirrors"], "r")
-        for line in mirrorsfile.readlines():
-            line = line.strip()
-            if line != "":
-                if ("#LOC:" in line):
-                    country_code = line.split(":")[1]
-                else:
-                    if country_code is not None:
-                        mirror = Mirror(line, country_code)
-                        self.base_mirrors.append(mirror)     
+        self.mirrors = self.read_mirror_list(self.config["mirrors"]["mirrors"])
+        self.base_mirrors = self.read_mirror_list(self.config["mirrors"]["base_mirrors"])
         
         self.repositories = []
         self.ppas = []
@@ -753,6 +732,22 @@ class Application(object):
         
         # From now on, we handle modifications to the settings and save them when they happen
         self._interface_loaded = True
+
+    def read_mirror_list(self, path):
+        mirror_list = []
+        country_code = None
+        mirrorsfile = open(path, "r")
+        for line in mirrorsfile.readlines():
+            line = line.strip()
+            if line != "":
+                if ("#LOC:" in line):
+                    country_code = line.split(":")[1]
+                else:
+                    if country_code is not None:
+                        if ("ubuntu-ports" not in line):
+                            mirror = Mirror(line, country_code)
+                            mirror_list.append(mirror)
+        return mirror_list
 
     def fix_purge(self, widget):
         os.system("aptitude purge ~c -y")


### PR DESCRIPTION
The mirror http://ftp.tu-chemnitz.de/pub/linux/ubuntu-ports/ was often the fastest one here, but it's for different architectures only.

That the mirrors.txt file in Ubuntu came up here, was because it had remembered the country code last found in the Mint mirror list when it started to check the Ubuntu mirrors and then thought this "mirror" was in South Africa too (ZA is the latest locale in the Mint mirror list). country_code = None avoids this.
