### PR TITLE
Allow adding deb lines through add-apt-repository

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -26,9 +26,9 @@ except ImportError:
 
 
 
-def add_ppa_via_cli(line, codename):   
+def add_repository_via_cli(line, codename):
 
-    if line is not None:
+    if line.startswith("ppa:"):
         user, sep, ppa_name = line.split(":")[1].partition("/")
         ppa_name = ppa_name or "ppa"
         try:
@@ -60,7 +60,10 @@ def add_ppa_via_cli(line, codename):
             # Add the PPA in sources.list.d
             with open(file, "w") as text_file:
                 text_file.write("%s\n" % deb_line)
-                text_file.write("%s\n" % debsrc_line)  
+                text_file.write("%s\n" % debsrc_line)
+    else if line.startswith("deb "):
+        with open("/etc/apt/sources.list.d/additional-repositories.list", "a") as text_file:
+            text_file.write("%s\n" % expand_http_line(line, codename))
 
 def get_ppa_info_from_lp(owner_name, ppa_name):
     DEFAULT_KEYSERVER = "hkp://keyserver.ubuntu.com:80/"
@@ -1199,6 +1202,6 @@ if __name__ == "__main__":
             config_parser = ConfigParser.RawConfigParser()
             config_parser.read("/usr/share/mintsources/%s/mintsources.conf" % lsb_codename)
             codename = config_parser.get("general", "base_codename")
-            add_ppa_via_cli(ppa_line, codename)
+            add_repository_via_cli(ppa_line, codename)
         else:
             Application().run()


### PR DESCRIPTION
Checking for faulty lines is not implemented yet, and it also doesn't yet add the deb-src line if source repos are enabled. I likely don't have time to implement those because of my vacation.
If I have not added these features by Friday, 26 July, you can merge the pull anyway: in its current state the code at least works for those people who get add-apt-repository commands from online tutorials.

The repository is added in the additional-repositories.list file, unlike ubuntu's version of add-apt-repository which added it in sources.list itself.

Line 63 had a trailing whitespace which is not shown by github.

I have renamed the add_ppa_via_cli function because it doesn't only add PPAs but also other sources now.
