### PR TITLE
adding -y option to force yes answer

### DIFF
--- a/usr/local/bin/add-apt-repository
+++ b/usr/local/bin/add-apt-repository
@@ -2,6 +2,7 @@
 
 import os, sys
 import gettext
+from optparse import OptionParser
 
 gettext.install("mintsources", "/usr/share/linuxmint/locale")
 
@@ -9,8 +10,21 @@ if os.geteuid() != 0:
     print(_("Error: must run as root"))
     sys.exit(1)
 
-if (len(sys.argv) < 2):
+usage = "usage: %prog [options] repository"
+parser = OptionParser(usage=usage)
+parser.add_option("-y", "--yes", dest="forceYes", action="store_true",
+    help="force yes on all confirmation questions", default=False)
+
+(options, args) = parser.parse_args()
+
+print options
+print args
+
+if (len(args) == 0):
     print(_("Error: need a repository as argument"))
     sys.exit(1)
 
-os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository \"%s\"" % sys.argv[1])
+if options.forceYes:
+    os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository -y \"%s\"" % args[0])
+else:
+	os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository \"%s\"" % args[0])


### PR DESCRIPTION
adding -y option to force yes answer to all. It requires an other modification I'm posting to other repository into mintSources.py. It will not break current implementation. When the other option is available it will work. Also adds -h help command

Check https://bugs.launchpad.net/linuxmint/+bug/1198751
