### PR TITLE
implementing --remove in add-apt-repository

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -1325,7 +1325,7 @@ if __name__ == "__main__":
             codename = config_parser.get("general", "base_codename")
             use_ppas = config_parser.get("general", "use_ppas")
             if options.remove:
-                remove_repository_via_cli(ppa_line, codename, options.forceYes, options.remove)
+                remove_repository_via_cli(ppa_line, codename, options.forceYes)
             else:
                 add_repository_via_cli(ppa_line, codename, options.forceYes, use_ppas)
         else:

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -26,7 +26,7 @@ except ImportError:
 from optparse import OptionParser
 from sets import Set
 
-def remove_repository_via_cli(line, codename, forceYes, remove):   
+def remove_repository_via_cli(line, codename, forceYes):   
     if line.startswith("ppa:"):
         user, sep, ppa_name = line.split(":")[1].partition("/")
         ppa_name = ppa_name or "ppa"

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -41,6 +41,11 @@ def remove_repository_via_cli(line, codename, forceYes):
                 if not(forceYes):
                     print(_("Press [ENTER] to continue or ctrl-c to cancel removing it"))
                     sys.stdin.readline()
+            else:
+                if not(forceYes):
+                        print(_("Unable to prompt for response.  Please run with -y"))
+                        sys.exit(1)
+                        
         except KeyboardInterrupt, detail:
             print _("Cancelling...")
             sys.exit(1)
@@ -1310,6 +1315,8 @@ if __name__ == "__main__":
     else:        
         usage = "usage: %prog [options] [repository]"
         parser = OptionParser(usage=usage)
+        #add a dummy option which can be easily ignored
+        parser.add_option("-?", dest="ignore", action="store_true", default=False)
         parser.add_option("-y", "--yes", dest="forceYes", action="store_true",
             help="force yes on all confirmation questions", default=False)
         parser.add_option("-r", "--remove", dest="remove", action="store_true",

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -26,6 +26,65 @@ except ImportError:
 from optparse import OptionParser
 from sets import Set
 
+def remove_repository_via_cli(line, codename, forceYes, remove):   
+    if line.startswith("ppa:"):
+        user, sep, ppa_name = line.split(":")[1].partition("/")
+        ppa_name = ppa_name or "ppa"
+        try:
+            ppa_info = get_ppa_info_from_lp(user, ppa_name)
+            print(_("You are about to remove the following PPA from your system:")) 
+            if ppa_info["description"] is not None:            
+                print(" %s" % (ppa_info["description"].encode("utf-8") or ""))
+            print(_(" More info: %s") % str(ppa_info["web_link"]))
+
+            if sys.stdin.isatty():
+                if not(forceYes):
+                    print(_("Press [ENTER] to continue or ctrl-c to cancel removing it"))
+                    sys.stdin.readline()
+        except KeyboardInterrupt, detail:
+            print _("Cancelling...")
+            sys.exit(1)
+        except Exception, detail:
+            print _("Cannot get info about PPA: '%s'.") % detail
+
+        (deb_line, file) = expand_ppa_line(line.strip(), codename)
+        deb_line = expand_http_line(deb_line, codename)
+        debsrc_line = 'deb-src' + deb_line[3:]
+            
+        # Remove the PPA from sources.list.d
+        try:
+            readfile = open(file, "r")
+            content = readfile.read()
+            readfile.close()
+            content = content.replace(deb_line, "")
+            content = content.replace(debsrc_line, "")
+            with open(file, "w") as writefile:
+                writefile.write(content)
+
+            # If file no longer contains any "deb" instances, delete it as well
+            if "deb " not in content:
+                os.unlink(file)
+        except IOError, detail:
+            print _("failed to remove PPA: '%s'") % detail
+
+    elif line.startswith("deb ") | line.startswith("http"):
+        # Remove the repository from sources.list.d
+        file="/etc/apt/sources.list.d/additional-repositories.list"
+        try:
+            readfile = open(file, "r")
+            content = readfile.read()
+            readfile.close()
+            content = content.replace(expand_http_line(line, codename), "")
+            with open(file, "w") as writefile:
+                writefile.write(content)
+
+            # If file no longer contains any "deb" instances, delete it as well
+            if "deb " not in content:
+                os.unlink(file)
+        except IOError, detail:
+            print _("failed to remove repository: '%s'") % detail
+
+
 def add_repository_via_cli(line, codename, forceYes, use_ppas):   
 
     if line.startswith("ppa:"):
@@ -1253,6 +1312,8 @@ if __name__ == "__main__":
         parser = OptionParser(usage=usage)
         parser.add_option("-y", "--yes", dest="forceYes", action="store_true",
             help="force yes on all confirmation questions", default=False)
+        parser.add_option("-r", "--remove", dest="remove", action="store_true",
+            help="Remove the specified repository", default=False)
 
         (options, args) = parser.parse_args()
 
@@ -1263,6 +1324,9 @@ if __name__ == "__main__":
             config_parser.read("/usr/share/mintsources/%s/mintsources.conf" % lsb_codename)
             codename = config_parser.get("general", "base_codename")
             use_ppas = config_parser.get("general", "use_ppas")
-            add_repository_via_cli(ppa_line, codename, options.forceYes, use_ppas)
+            if options.remove:
+                remove_repository_via_cli(ppa_line, codename, options.forceYes, options.remove)
+            else:
+                add_repository_via_cli(ppa_line, codename, options.forceYes, use_ppas)
         else:
             Application().run()

--- a/usr/local/bin/add-apt-repository
+++ b/usr/local/bin/add-apt-repository
@@ -14,6 +14,8 @@ usage = "usage: %prog [options] repository"
 parser = OptionParser(usage=usage)
 parser.add_option("-y", "--yes", dest="forceYes", action="store_true",
     help="force yes on all confirmation questions", default=False)
+parser.add_option("-r", "--remove", dest="remove", action="store_true",
+    help="Remove the specified repository", default=False)
 
 (options, args) = parser.parse_args()
 
@@ -21,7 +23,9 @@ if (len(args) == 0):
     print(_("Error: need a repository as argument"))
     sys.exit(1)
 
+option_string=""
 if options.forceYes:
-	os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository -y \"%s\"" % args[0])
-else:
-	os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository \"%s\"" % args[0])
+  option_string+=" -y "
+if options.remove:
+  option_string+=" --remove "
+os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository %s \"%s\"" % (option_string, args[0]))

--- a/usr/local/bin/add-apt-repository
+++ b/usr/local/bin/add-apt-repository
@@ -25,7 +25,7 @@ if (len(args) == 0):
 
 option_string=""
 if options.forceYes:
-  option_string+=" -y "
+    option_string+=" -y "
 if options.remove:
-  option_string+=" --remove "
+    option_string+=" --remove "
 os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository %s \"%s\"" % (option_string, args[0]))

--- a/usr/local/bin/add-apt-repository
+++ b/usr/local/bin/add-apt-repository
@@ -28,4 +28,4 @@ if options.forceYes:
     option_string+=" -y "
 if options.remove:
     option_string+=" --remove "
-os.system("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository %s \"%s\"" % (option_string, args[0]))
+os.execl("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository %s \"%s\"" % (option_string, args[0]))

--- a/usr/local/bin/add-apt-repository
+++ b/usr/local/bin/add-apt-repository
@@ -26,9 +26,13 @@ if (len(args) == 0):
 # Call mintSources script with exec instead of system so that the exit status
 # is returned to the caller
 mintsources = "/usr/lib/linuxmint/mintSources/mintSources.py"
-option_string=""
+
+yes_arg="-?"
 if options.forceYes:
-    option_string+=" -y "
+    yes_arg="-y"
+
+remove_arg="-?"
 if options.remove:
-    option_string+=" --remove "
-os.execl(mintsources, mintsources, "add-apt-repository", option_string, args[0])
+    remove_arg="-r"
+
+os.execl(mintsources, mintsources, "add-apt-repository", yes_arg, remove_arg, args[0])

--- a/usr/local/bin/add-apt-repository
+++ b/usr/local/bin/add-apt-repository
@@ -23,9 +23,12 @@ if (len(args) == 0):
     print(_("Error: need a repository as argument"))
     sys.exit(1)
 
+# Call mintSources script with exec instead of system so that the exit status
+# is returned to the caller
+mintsources = "/usr/lib/linuxmint/mintSources/mintSources.py"
 option_string=""
 if options.forceYes:
     option_string+=" -y "
 if options.remove:
     option_string+=" --remove "
-os.execl("/usr/lib/linuxmint/mintSources/mintSources.py add-apt-repository %s \"%s\"" % (option_string, args[0]))
+os.execl(mintsources, mintsources, "add-apt-repository", option_string, args[0])


### PR DESCRIPTION
This is my first attempt to use GIT / submit code changes to a project's codebase.  

Temporarily adding "experimental" repositories is one reason to need --delete.  This is the example I was using for testing.

add-apt-repository ppa:wasta-linux/wasta-testing --yes
add-apt-repository "deb http://packages.sil.org/ubuntu precise-experimental main"

echo && echo && echo 
read -p "Press <ENTER> when finished, to remove the testing repos:  " JUNK

add-apt-repository --remove ppa:wasta-linux/wasta-testing
add-apt-repository --remove "deb http://packages.sil.org/ubuntu precise-experimental main"
