### PR TITLE
Add software-properties-gtk and software-properties-kde as provided packages.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ Package: mintsources
 Architecture: all
 Depends: python (>= 2.4), python (<< 3), python-gtk2, python-glade2, python-pycurl, synaptic
 Conflicts: software-properties-gtk, software-properties-kde
+Provides: software-properties-gtk, software-properties-kde
 Description: Software Sources configuration tool
  Configure the sources for installable software and updates.


### PR DESCRIPTION
mintsources conflicts with these packages, which leads to nasty dependency
handling behavior in apt. Since it provides exactly the same functionality,
and very few packages actually have these dependencies, we can specify that
we provide these packages and avoid any trouble or the need to manually build
copies of all sorts of things.
