### PR TITLE
fix debian-changelog-file-contains-invalid-email-address

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -192,19 +192,19 @@ mintsources (1.0.5) olivia; urgency=low
 
   * 1.0.5
 
- -- Clement Lefebvre <clem@vaio>  Thu, 04 Apr 2013 12:40:21 +0100
+ -- Clement Lefebvre <root@linuxmint.com>  Thu, 04 Apr 2013 12:40:21 +0100
 
 mintsources (1.0.4) olivia; urgency=low
 
   * 1.0.4
 
- -- Clement Lefebvre <clem@vaio>  Sat, 30 Mar 2013 14:57:27 +0000
+ -- Clement Lefebvre <root@linuxmint.com>  Sat, 30 Mar 2013 14:57:27 +0000
 
 mintsources (1.0.3) olivia; urgency=low
 
   * 1.0.3
 
- -- Clement Lefebvre <clem@toshiba>  Fri, 29 Mar 2013 17:54:25 +0000
+ -- Clement Lefebvre <root@linuxmint.com>  Fri, 29 Mar 2013 17:54:25 +0000
 
 mintsources (1.0.2) olivia; urgency=low
 


### PR DESCRIPTION
I know it's uncommon to edit old changelog entries, but I think in this case an exception should be made.
https://lintian.debian.org/tags/debian-changelog-file-contains-invalid-email-address.html
