### PR TITLE
Fix crash in Select Mirror on no connection

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -494,7 +494,8 @@ class MirrorSelectionDialog(object):
 
             if (iter is not None): # recheck as it can get null
                 if download_speed == 0:
-                    model.remove(iter)
+                    # don't remove from model as this is not thread-safe
+                    model.set_value(iter, MirrorSelectionDialog.MIRROR_SPEED_LABEL_COLUMN, "offline")
                 else:
                     model.set_value(iter, MirrorSelectionDialog.MIRROR_SPEED_COLUMN, download_speed)
                     model.set_value(iter, MirrorSelectionDialog.MIRROR_SPEED_LABEL_COLUMN, self._get_speed_label(download_speed))


### PR DESCRIPTION
Until now, we remove mirrors from the Mirror Selection dialog if they
aren't available. Sometimes this works fine but sometimes or if many
servers are unavailable e.g. due to no internet connection on the user
side, the list gets unsynchronized and crashes our script as removing
entries from a GtkListStore is not thread-safe.
Instead of making the whole thing thread-safe (with locks and
everything), this commit displays an "offline" label in the speed column
of such servers.

That way, the user is still able to select (seemingly) offline servers
but I consider this behavior quite appropriate and better than
presenting an empty list, which would be the consequence if the current
approach were thread-safe and the user started the tool without being
online.

This fixes linuxmint/mintsources#65