### PR TITLE
Fixed dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: mintsources
 Architecture: all
 Essential: yes
-Depends: python (>= 2.4), python (<< 3), python-gtk2, python-glade2, python-pycurl, synaptic, dash
+Depends: python (>= 2.4), python (<< 3), python-gtk2, python-glade2, python-pycurl, synaptic, dash, lsb-release
 Replaces: software-properties-common (<< 1), software-properties-gtk (<< 1), software-properties-kde (<< 1), python-software-properties (<< 1), python3-software-properties (<< 1)
 Description: Software Sources configuration tool
  Configure the sources for installable software and updates.


### PR DESCRIPTION
Lsb_release command is used to get distribution info by mintsources at mintSources.py.
But it's missing at dependency description.