### PR TITLE
Set mint sources to the mintsources icon

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -674,7 +674,7 @@ class Application(object):
 
         self._main_window.set_title(_("Software Sources"))
 
-        self._main_window.set_icon_from_file("/usr/share/icons/hicolor/scalable/apps/software-sources.svg")
+        self._main_window.set_icon_name("mintsources")
 
         self._notebook = self.builder.get_object("notebook")
         self._official_repositories_box = self.builder.get_object("official_repositories_box")


### PR DESCRIPTION
This makes the icon used consistent everywhere. The main menu, window list, mintupdate, cinnamon-settings, etc.