### PR TITLE
Allow adding http repositories with line expansion

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -138,7 +138,7 @@ def add_repository_via_cli(line, codename, forceYes, use_ppas):
         with open(file, "w") as text_file:
             text_file.write("%s\n" % deb_line)
             text_file.write("%s\n" % debsrc_line)
-    elif line.startswith("deb "):
+    elif line.startswith("deb ") | line.startswith("http"):
         with open("/etc/apt/sources.list.d/additional-repositories.list", "a") as text_file:
             text_file.write("%s\n" % expand_http_line(line, codename))
 


### PR DESCRIPTION
The current code does not support the following syntax which is supported by Ubuntu:
```
sudo apt-add-repository https://example.com/packages/
```
The script currently ignores the whole line without printing any error. Only lines starting with `ppa:` or `deb ` are processed. It is still possible to add the repository by using `sudo apt-add-repository "deb https://example.com/packages/ xenial main"` but this requires the user to manually enter the code name of the distro making installation instructions unnecessary complicated. The small change fixes the issue, as the necessary logic is still implemented in `expand_http_line`.