### PR TITLE
Add a mintsources icon to the hicolor theme

### DIFF
--- a/usr/share/icons/hicolor/scalable/apps/mintsources.svg
+++ b/usr/share/icons/hicolor/scalable/apps/mintsources.svg
@@ -1,0 +1,1491 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="96"
+   height="96"
+   id="svg2408"
+   style="display:inline">
+  <defs
+     id="defs2410">
+    <linearGradient
+       id="linearGradient3778">
+      <stop
+         id="stop3780"
+         style="stop-color:#1e74af;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3782"
+         style="stop-color:#84c0ea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4426">
+      <stop
+         id="stop4428"
+         style="stop-color:#71461e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4430"
+         style="stop-color:#71461e;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4414">
+      <stop
+         id="stop4416"
+         style="stop-color:#dac3a2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4418"
+         style="stop-color:#dac3a2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4370">
+      <stop
+         id="stop4372"
+         style="stop-color:#8a5b30;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4374"
+         style="stop-color:#8a5b30;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4295">
+      <stop
+         id="stop4297"
+         style="stop-color:#b88f56;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4299"
+         style="stop-color:#d9bd98;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4289">
+      <stop
+         id="stop4291"
+         style="stop-color:#996c3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4293"
+         style="stop-color:#c19e6d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5092">
+      <stop
+         id="stop5094"
+         style="stop-color:#be9f6a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5096"
+         style="stop-color:#e5d2b2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5010">
+      <stop
+         id="stop5012"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5014"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(1.0058652,0.994169)">
+      <stop
+         id="stop3750"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3737">
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="54.187183"
+       y1="90"
+       x2="54.187183"
+       y2="39.852562"
+       id="linearGradient3706"
+       xlink:href="#linearGradient4289"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3174">
+      <feGaussianBlur
+         id="feGaussianBlur3176"
+         stdDeviation="1.71" />
+    </filter>
+    <filter
+       x="-0.31155673"
+       y="-0.42628157"
+       width="1.6231135"
+       height="1.8525631"
+       color-interpolation-filters="sRGB"
+       id="filter4362">
+      <feGaussianBlur
+         id="feGaussianBlur4364"
+         stdDeviation="6.2124381" />
+    </filter>
+    <linearGradient
+       x1="47.079498"
+       y1="32.782871"
+       x2="6.5962563"
+       y2="9.4098616"
+       id="linearGradient5100"
+       xlink:href="#linearGradient5092"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="48"
+       y1="42"
+       x2="6.7812738"
+       y2="18.202358"
+       id="linearGradient2489"
+       xlink:href="#linearGradient4295"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="47.226776"
+       y1="29.039698"
+       x2="6.3304405"
+       y2="18.081558"
+       id="linearGradient3264"
+       xlink:href="#linearGradient4295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,96,0)" />
+    <linearGradient
+       x1="23.142857"
+       y1="42"
+       x2="66.964287"
+       y2="6"
+       id="linearGradient3285"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="8"
+       y1="38.127232"
+       x2="8"
+       y2="71.877235"
+       id="linearGradient4376"
+       xlink:href="#linearGradient4370"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="10"
+       y1="40.263424"
+       x2="10"
+       y2="89.666374"
+       id="linearGradient4394"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="8"
+       y1="38.127232"
+       x2="8"
+       y2="87.029526"
+       id="linearGradient4400"
+       xlink:href="#linearGradient4370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,96,0)" />
+    <linearGradient
+       x1="10"
+       y1="40.263424"
+       x2="10"
+       y2="89.666374"
+       id="linearGradient4402"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,96,0)" />
+    <linearGradient
+       x1="8.9651041"
+       y1="44.040279"
+       x2="8.9651041"
+       y2="52.263294"
+       id="linearGradient4420"
+       xlink:href="#linearGradient4414"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="8.9651041"
+       y1="44.040279"
+       x2="8.9651041"
+       y2="52.263294"
+       id="linearGradient4424"
+       xlink:href="#linearGradient4414"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,96.086934,0)" />
+    <radialGradient
+       cx="48"
+       cy="73.14563"
+       r="42"
+       fx="48"
+       fy="73.14563"
+       id="radialGradient4432"
+       xlink:href="#linearGradient4426"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.867765,0,0,0.09523809,6.3472804,36.190476)" />
+    <linearGradient
+       x1="65.262688"
+       y1="64.205269"
+       x2="65.262688"
+       y2="50.068527"
+       id="linearGradient3832"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.625,0,0,0.625,28.5,31.25)" />
+    <linearGradient
+       id="linearGradient3737-4">
+      <stop
+         id="stop3739-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="48"
+       cy="90.171875"
+       r="42"
+       fx="48"
+       fy="90.171875"
+       id="radialGradient2858"
+       xlink:href="#linearGradient3737-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1573129,0,0,0.99590774,-7.551021,0.1971319)" />
+    <linearGradient
+       x1="56"
+       y1="72"
+       x2="88"
+       y2="72"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9375,0,0,0.9375,-140.5,3.5)" />
+    <linearGradient
+       x1="70"
+       y1="54"
+       x2="70"
+       y2="75.095024"
+       id="linearGradient3788"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,4)" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3806">
+      <feGaussianBlur
+         id="feGaussianBlur3808"
+         stdDeviation="1.2" />
+    </filter>
+    <linearGradient
+       x1="65.262688"
+       y1="64.205269"
+       x2="65.262688"
+       y2="50.068527"
+       id="linearGradient3812"
+       xlink:href="#linearGradient5010"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.625,0,0,0.625,78.5,32.25)" />
+    <clipPath
+       id="clipPath3823">
+      <path
+         d="M 108.8125,58 C 107.25437,58 106,59.254375 106,60.8125 l 0,24.375 C 106,86.745625 107.25437,88 108.8125,88 l 24.375,0 C 134.74562,88 136,86.745625 136,85.1875 l 0,-24.375 C 136,59.254375 134.74562,58 133.1875,58 l -24.375,0 z m 7.1875,4.5 10,0 0,8.75 5,0 -10,13.75 -10,-13.75 5,0 0,-8.75 z"
+         inkscape:connector-curvature="0"
+         id="path3825"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </clipPath>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3831">
+      <feGaussianBlur
+         id="feGaussianBlur3833"
+         stdDeviation="0.6375" />
+    </filter>
+    <linearGradient
+       x1="51.42857"
+       y1="72.785713"
+       x2="90.714287"
+       y2="72.785713"
+       id="linearGradient3844"
+       xlink:href="#linearGradient3778"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath3871">
+      <path
+         d="M 0,95.999997 0,156 l 96.000001,0 0,-60.000003 -96.000001,0 z M 68,116 c 9.941125,0 18,8.05888 18,18 0,9.94112 -8.058875,18 -18,18 -9.941125,0 -18,-8.05888 -18,-18 0,-9.94112 8.058875,-18 18,-18 z"
+         inkscape:connector-curvature="0"
+         id="path3873"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </clipPath>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3866">
+      <feGaussianBlur
+         id="feGaussianBlur3868"
+         stdDeviation="1.44" />
+    </filter>
+    <linearGradient
+       x1="64.321426"
+       y1="55.310268"
+       x2="64.321426"
+       y2="84.889679"
+       id="linearGradient3857-6"
+       xlink:href="#linearGradient3737-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,0)" />
+    <linearGradient
+       id="linearGradient3737-1">
+      <stop
+         id="stop3739-5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-9"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2312">
+      <stop
+         id="stop2314"
+         style="stop-color:#e3ebf3;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2316"
+         style="stop-color:#cedceb;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="22.109167"
+       cy="19.780535"
+       r="19.18985"
+       fx="22.109167"
+       fy="19.780535"
+       id="radialGradient3146"
+       xlink:href="#linearGradient2312"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94406626,0,0,0.88116978,44.405871,53.026474)" />
+    <radialGradient
+       cx="59.893993"
+       cy="61.92226"
+       r="33.71384"
+       fx="59.893993"
+       fy="61.92226"
+       id="radialGradient3348"
+       xlink:href="#linearGradient3342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.8375435,0,10.059672)" />
+    <linearGradient
+       id="linearGradient3342">
+      <stop
+         id="stop3344"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3350"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0.85000002" />
+      <stop
+         id="stop3346"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="26.180153"
+       y1="61.92226"
+       x2="93.607834"
+       y2="61.92226"
+       id="linearGradient3336"
+       xlink:href="#linearGradient3330"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3330">
+      <stop
+         id="stop3332"
+         style="stop-color:#ffffff;stop-opacity:0.203125"
+         offset="0" />
+      <stop
+         id="stop3334"
+         style="stop-color:#ffffff;stop-opacity:0.6796875"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.220379"
+       y1="61.92226"
+       x2="94.567612"
+       y2="61.92226"
+       id="linearGradient3368"
+       xlink:href="#linearGradient3362"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3362">
+      <stop
+         id="stop3364"
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3366"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="73.015572"
+       y1="89.130737"
+       x2="73.015572"
+       y2="34.606899"
+       id="linearGradient3178"
+       xlink:href="#ButtonColor"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8050811,0,0,2.1684415,-44.113515,-70.274799)" />
+    <linearGradient
+       x1="58.650177"
+       y1="122"
+       x2="58.650177"
+       y2="5.4252338"
+       id="ButtonColor"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0172414,0,0,1.0172414,-1.1034483,-1.1034483)">
+      <stop
+         id="stop3189"
+         style="stop-color:#b8abbd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3191"
+         style="stop-color:#dddbde;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3239"
+       xlink:href="#linearGradient3233"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8660254,0.5,-0.5,0.8660254,40.574374,-23.072269)" />
+    <linearGradient
+       id="linearGradient3233">
+      <stop
+         id="stop3235"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3297"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.15000001" />
+      <stop
+         id="stop3241"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3299"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.85000002" />
+      <stop
+         id="stop3237"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <clipPath
+       id="clipPath3271">
+      <rect
+         width="118"
+         height="59"
+         x="5"
+         y="160.00336"
+         id="rect3273"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    </clipPath>
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3299"
+       xlink:href="#linearGradient3236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.9850397,0.171492,-0.171492,-0.9850397,138.01803,271.06706)" />
+    <linearGradient
+       id="linearGradient3236">
+      <stop
+         id="stop3238"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3240"
+         style="stop-color:#fffc2b;stop-opacity:0.234375"
+         offset="0.34999999" />
+      <stop
+         id="stop3242"
+         style="stop-color:#46d15d;stop-opacity:0.21875"
+         offset="0.5" />
+      <stop
+         id="stop3244"
+         style="stop-color:#46d1aa;stop-opacity:0"
+         offset="0.64999998" />
+      <stop
+         id="stop3246"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3301"
+       xlink:href="#linearGradient3265"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.8529965,0.5216416,-0.5216416,-0.8529964,151.97682,240.20671)" />
+    <linearGradient
+       id="linearGradient3265">
+      <stop
+         id="stop3267"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3252"
+         style="stop-color:#afcff3;stop-opacity:0"
+         offset="0.2" />
+      <stop
+         id="stop3269"
+         style="stop-color:#60a0e7;stop-opacity:0.1484375"
+         offset="0.34999999" />
+      <stop
+         id="stop3271"
+         style="stop-color:#db8ef1;stop-opacity:0.2109375"
+         offset="0.5" />
+      <stop
+         id="stop3273"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.64999998" />
+      <stop
+         id="stop3275"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3303"
+       xlink:href="#linearGradient3247"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.881451,-0.4719713,0.4719713,-0.881451,90.206697,305.61903)" />
+    <linearGradient
+       id="linearGradient3247">
+      <stop
+         id="stop3249"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3293"
+         style="stop-color:#d5d5d5;stop-opacity:0"
+         offset="0.30000001" />
+      <stop
+         id="stop3251"
+         style="stop-color:#eb8888;stop-opacity:0.2578125"
+         offset="0.5" />
+      <stop
+         id="stop3295"
+         style="stop-color:#e28f25;stop-opacity:0"
+         offset="0.69999999" />
+      <stop
+         id="stop3253"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3305"
+       xlink:href="#linearGradient3236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.9850397,0.171492,-0.171492,-0.9850397,138.01803,271.06706)" />
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3307"
+       xlink:href="#linearGradient3265"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.8529965,0.5216416,-0.5216416,-0.8529964,151.97682,240.20671)" />
+    <linearGradient
+       x1="5"
+       y1="64"
+       x2="123"
+       y2="64"
+       id="linearGradient3309"
+       xlink:href="#linearGradient3247"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.881451,-0.4719713,0.4719713,-0.881451,90.206697,305.61903)" />
+    <linearGradient
+       x1="64.321426"
+       y1="55.310268"
+       x2="64.321426"
+       y2="84.889679"
+       id="linearGradient3857-6-8"
+       xlink:href="#linearGradient3737-1-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,0)" />
+    <linearGradient
+       id="linearGradient3737-1-4">
+      <stop
+         id="stop3739-5-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-9-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0058652,0,0,0.994169,100,0)">
+      <stop
+         id="stop3750-8"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-5"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.251034"
+       y1="6.1317081"
+       x2="32.251034"
+       y2="90.238609"
+       id="linearGradient3780"
+       xlink:href="#ButtonShadow-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0238095,0,0,1.0119048,-1.1428571,-98.071429)" />
+    <linearGradient
+       x1="32.251034"
+       y1="6.1317081"
+       x2="32.251034"
+       y2="90.238609"
+       id="linearGradient3772"
+       xlink:href="#ButtonShadow-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0238095,0,0,1.0119048,-1.1428571,-98.071429)" />
+    <linearGradient
+       x1="32.251034"
+       y1="6.1317081"
+       x2="32.251034"
+       y2="90.238609"
+       id="linearGradient3725"
+       xlink:href="#ButtonShadow-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0238095,0,0,1.0119048,-1.1428571,-98.071429)" />
+    <linearGradient
+       x1="32.251034"
+       y1="6.1317081"
+       x2="32.251034"
+       y2="90.238609"
+       id="linearGradient3721"
+       xlink:href="#ButtonShadow-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-97)" />
+    <linearGradient
+       x1="32.251034"
+       y1="6.1317081"
+       x2="32.251034"
+       y2="90.238609"
+       id="linearGradient2918"
+       xlink:href="#ButtonShadow-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0238095,0,0,1.0119048,-1.1428571,-98.071429)" />
+    <linearGradient
+       x1="50.499405"
+       y1="19.881863"
+       x2="50.499405"
+       y2="47.295406"
+       id="linearGradient3277-4"
+       xlink:href="#linearGradient4309-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0200612,0,0,1.0200612,-5.2981966,5.7562054)" />
+    <linearGradient
+       x1="52.25"
+       y1="47.247101"
+       x2="52.25"
+       y2="0.2393"
+       id="linearGradient4309-0"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4311-0"
+         style="stop-color:#d8cab2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4321-6"
+         style="stop-color:#d2b98c;stop-opacity:1"
+         offset="0.45710954" />
+      <stop
+         id="stop4323-2"
+         style="stop-color:#f9f7ef;stop-opacity:1"
+         offset="0.48590001" />
+      <stop
+         id="stop4325-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.49110001" />
+      <stop
+         id="stop4327-6"
+         style="stop-color:#fbf9f4;stop-opacity:1"
+         offset="0.49180001" />
+      <stop
+         id="stop4329-8"
+         style="stop-color:#efe7d0;stop-opacity:1"
+         offset="0.4946" />
+      <stop
+         id="stop4331-3"
+         style="stop-color:#e4d6b0;stop-opacity:1"
+         offset="0.49770001" />
+      <stop
+         id="stop4333-3"
+         style="stop-color:#dac894;stop-opacity:1"
+         offset="0.5011" />
+      <stop
+         id="stop4335-4"
+         style="stop-color:#c7a572;stop-opacity:1"
+         offset="0.50489998" />
+      <stop
+         id="stop4347-8"
+         style="stop-color:#d7c198;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="46.795631"
+       y1="60.307007"
+       x2="46.795631"
+       y2="6.0179305"
+       id="linearGradient3942"
+       xlink:href="#linearGradient3928"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3928">
+      <stop
+         id="stop3930"
+         style="stop-color:#3a240f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3932"
+         style="stop-color:#3a240f;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="48.40115"
+       y1="61.990967"
+       x2="48.40115"
+       y2="4.6666145"
+       id="linearGradient3934"
+       xlink:href="#linearGradient3928"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath3871-0">
+      <path
+         d="M 0,95.999997 0,156 l 96.000001,0 0,-60.000003 -96.000001,0 z M 68,116 c 9.941125,0 18,8.05888 18,18 0,9.94112 -8.058875,18 -18,18 -9.941125,0 -18,-8.05888 -18,-18 0,-9.94112 8.058875,-18 18,-18 z"
+         inkscape:connector-curvature="0"
+         id="path3873-0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata2413">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer2"
+     style="display:none">
+    <path
+       d="M 11,7 48,5 85,7 c 3.324,0 6,2.676 6,6 l 0,73 c 0,3.324 -2.676,6 -6,6 L 11,92 C 7.676,92 5,89.324 5,86 L 5,13 C 5,9.676 7.676,7 11,7 z"
+       inkscape:connector-curvature="0"
+       id="rect3745"
+       style="opacity:0.9;fill:url(#ButtonShadow);fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter3174)" />
+  </g>
+  <g
+     id="layer8"
+     style="display:inline">
+    <path
+       d="m 12,-95.03125 c -5.5110903,0 -10.03125,4.52016 -10.03125,10.03125 l 0,71 c 0,5.5110902 4.5201598,10.03125 10.03125,10.03125 l 72,0 c 5.51109,0 10.03125,-4.5201597 10.03125,-10.03125 l 0,-71 c 0,-5.51109 -4.52016,-10.03125 -10.03125,-10.03125 l -72,0 z"
+       transform="scale(1,-1)"
+       id="path3786"
+       style="opacity:0.07999998;fill:url(#linearGradient2918);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+    <path
+       d="m 12,-94.03125 c -4.971633,0 -9.03125,4.059617 -9.03125,9.03125 l 0,71 c 0,4.9716329 4.0596171,9.03125 9.03125,9.03125 l 72,0 c 4.971633,0 9.03125,-4.059617 9.03125,-9.03125 l 0,-71 c 0,-4.971633 -4.059617,-9.03125 -9.03125,-9.03125 l -72,0 z"
+       transform="scale(1,-1)"
+       id="path3778"
+       style="opacity:0.1;fill:url(#linearGradient3780);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+    <path
+       d="m 12,-93 c -4.4091333,0 -8,3.590867 -8,8 l 0,71 c 0,4.4091333 3.5908667,8 8,8 l 72,0 c 4.409133,0 8,-3.5908667 8,-8 l 0,-71 c 0,-4.409133 -3.590867,-8 -8,-8 l -72,0 z"
+       transform="scale(1,-1)"
+       id="path3770"
+       style="opacity:0.2;fill:url(#linearGradient3772);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+    <rect
+       width="86"
+       height="85"
+       rx="7"
+       ry="7"
+       x="5"
+       y="-92"
+       transform="scale(1,-1)"
+       id="rect3723"
+       style="opacity:0.3;fill:url(#linearGradient3725);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+    <rect
+       width="84"
+       height="84"
+       rx="6"
+       ry="6"
+       x="6"
+       y="-91"
+       transform="scale(1,-1)"
+       id="rect3716"
+       style="opacity:0.45;fill:url(#linearGradient3721);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+  </g>
+  <g
+     id="layer1"
+     style="display:inline">
+    <path
+       d="m 6,36 0,48 c 0,1.781762 0.7745675,3.371709 2,4.46875 L 8,36 6,36 z"
+       inkscape:connector-curvature="0"
+       id="rect5138"
+       style="fill:url(#linearGradient4376);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       width="84"
+       height="84"
+       rx="6"
+       ry="6"
+       x="6"
+       y="6"
+       id="rect2419"
+       style="fill:url(#linearGradient3706);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 6,36 0,2 c 0,3.324 2.676,6 6,6 l 72,0 c 3.324,0 6,-2.676 6,-6 l 0,-2 c 0,3.324 -2.676,6 -6,6 L 12,42 C 8.676,42 6,39.324 6,36 z"
+       inkscape:connector-curvature="0"
+       id="path3287"
+       style="fill:url(#radialGradient4432);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 90,36 0,48 c 0,1.781762 -0.774567,3.371709 -2,4.46875 L 88,36 l 2,0 z"
+       inkscape:connector-curvature="0"
+       id="path4396"
+       style="fill:url(#linearGradient4400);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       width="84"
+       height="24"
+       rx="6"
+       ry="6"
+       x="6"
+       y="18"
+       id="rect2483"
+       style="fill:#3c2510;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 88,36 0,52.46875 c -0.576856,0.516417 -1.254924,0.923089 -2,1.1875 L 86,36 l 2,0 z"
+       inkscape:connector-curvature="0"
+       id="path4398"
+       style="opacity:0.3;fill:url(#linearGradient4402);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 8,36 0,52.46875 c 0.5768558,0.516417 1.254924,0.923089 2,1.1875 L 10,36 8,36 z"
+       inkscape:connector-curvature="0"
+       id="path4378"
+       style="opacity:0.3;fill:url(#linearGradient4394);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 12,6 C 8.7734181,6 6,8.2592995 6,13 L 6,15 6,35.65625 48,35.69067 48,6 14,6 12,6 z"
+       inkscape:connector-curvature="0"
+       id="path5055"
+       style="fill:url(#linearGradient5100);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       width="47.855976"
+       height="34.976532"
+       rx="6"
+       ry="6"
+       x="12.753176"
+       y="41.956837"
+       transform="matrix(1,0,0,0.8555957,10,8.5841304)"
+       id="rect4356"
+       style="opacity:0.3;fill:#dac7a8;fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter4362)" />
+    <path
+       d="M 12,6 C 8.676,6 6,8.676 6,12 l 0,24 c 0,3.324 2.676,6 6,6 L 48,40 48,4 12,6 z"
+       inkscape:connector-curvature="0"
+       id="rect2481"
+       style="fill:url(#linearGradient2489);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 84,6 c 3.324,0 6,2.676 6,6 l 0,24 c 0,3.324 -2.676,6 -6,6 L 48,40 48,4 84,6 z"
+       inkscape:connector-curvature="0"
+       id="path3262"
+       style="fill:url(#linearGradient3264);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 12,6 C 8.676,6 6,8.676 6,12 l 0,24 c 0,3.324 2.676,6 6,6 l 36,-2 36,2 c 3.324,0 6,-2.676 6,-6 L 90,12 C 90,8.676 87.324,6 84,6 L 48,4 12,6 z m 0,2 36,-2 36,2 c 2.245802,0 4,1.7541975 4,4 l 0,24 c 0,2.245802 -1.754198,4 -4,4 L 48,38 12,40 C 9.7541975,40 8,38.245802 8,36 L 8,12 C 8,9.7541975 9.7541975,8 12,8 z"
+       inkscape:connector-curvature="0"
+       id="rect3266"
+       style="opacity:0.3;fill:url(#linearGradient3285);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 6.1871843,37.284884 c 2.3991123,5.555839 1.894036,16.036171 1.894036,16.036171 L 9.9121217,53.068517 C 9.6595836,44.861028 10.354063,41.83057 14.89975,41.704301 7.7307581,40.509469 6.1871843,37.284884 6.1871843,37.284884 z"
+       inkscape:connector-curvature="0"
+       id="path4404"
+       style="fill:url(#linearGradient4420);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <path
+       d="m 89.89975,37.284884 c -2.399112,5.555839 -1.894036,16.036171 -1.894036,16.036171 L 86.174813,53.068517 C 86.427351,44.861028 85.732871,41.83057 81.187184,41.704301 88.356176,40.509469 89.89975,37.284884 89.89975,37.284884 z"
+       inkscape:connector-curvature="0"
+       id="path4422"
+       style="fill:url(#linearGradient4424);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <path
+       d="M 12,90 C 8.676,90 6,87.324 6,84 L 6,82 6,14 6,12 c 0,-0.334721 0.04135,-0.6507 0.09375,-0.96875 0.0487,-0.295596 0.09704,-0.596915 0.1875,-0.875 C 6.29113,10.12587 6.302142,10.09265 6.3125,10.0625 6.411365,9.774729 6.5473802,9.515048 6.6875,9.25 6.8320918,8.976493 7.0031161,8.714385 7.1875,8.46875 7.3718839,8.223115 7.5612765,7.995278 7.78125,7.78125 8.221197,7.353194 8.72416,6.966724 9.28125,6.6875 9.559795,6.547888 9.8547231,6.440553 10.15625,6.34375 9.9000482,6.443972 9.6695391,6.580022 9.4375,6.71875 c -0.00741,0.0044 -0.023866,-0.0045 -0.03125,0 -0.031933,0.0193 -0.062293,0.04251 -0.09375,0.0625 -0.120395,0.0767 -0.2310226,0.163513 -0.34375,0.25 -0.1061728,0.0808 -0.2132809,0.161112 -0.3125,0.25 C 8.4783201,7.442683 8.3087904,7.626638 8.15625,7.8125 8.0486711,7.942755 7.9378561,8.077785 7.84375,8.21875 7.818661,8.25713 7.805304,8.30462 7.78125,8.34375 7.716487,8.446782 7.6510225,8.548267 7.59375,8.65625 7.4927417,8.850956 7.3880752,9.071951 7.3125,9.28125 7.30454,9.30306 7.288911,9.3218 7.28125,9.34375 7.2494249,9.4357 7.2454455,9.530581 7.21875,9.625 7.1884177,9.731618 7.1483606,9.828031 7.125,9.9375 7.0521214,10.279012 7,10.635705 7,11 l 0,2 0,68 0,2 c 0,2.781848 2.2181517,5 5,5 l 2,0 68,0 2,0 c 2.781848,0 5,-2.218152 5,-5 l 0,-2 0,-68 0,-2 C 89,10.635705 88.94788,10.279012 88.875,9.9375 88.83085,9.730607 88.78662,9.539842 88.71875,9.34375 88.71105,9.3218 88.69545,9.30306 88.6875,9.28125 88.62476,9.107511 88.549117,8.913801 88.46875,8.75 88.42717,8.6672 88.38971,8.580046 88.34375,8.5 88.28915,8.40279 88.216976,8.31165 88.15625,8.21875 88.06214,8.077785 87.951329,7.942755 87.84375,7.8125 87.700576,7.63805 87.540609,7.465502 87.375,7.3125 87.36383,7.3023 87.35502,7.29135 87.34375,7.28125 87.205364,7.155694 87.058659,7.046814 86.90625,6.9375 86.803679,6.86435 86.701932,6.784136 86.59375,6.71875 c -0.0074,-0.0045 -0.02384,0.0044 -0.03125,0 -0.232039,-0.138728 -0.462548,-0.274778 -0.71875,-0.375 0.301527,0.0968 0.596455,0.204138 0.875,0.34375 0.55709,0.279224 1.060053,0.665694 1.5,1.09375 0.219973,0.214028 0.409366,0.441865 0.59375,0.6875 0.184384,0.245635 0.355408,0.507743 0.5,0.78125 0.14012,0.265048 0.276135,0.524729 0.375,0.8125 0.01041,0.03078 0.02133,0.06274 0.03125,0.09375 0.09046,0.278085 0.1388,0.579404 0.1875,0.875 C 89.95865,11.3493 90,11.665279 90,12 l 0,2 0,68 0,2 c 0,3.324 -2.676,6 -6,6 l -72,0 z"
+       inkscape:connector-curvature="0"
+       id="path3615"
+       style="opacity:0.2;fill:url(#radialGradient2858);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="M 54.120367,7 42.000001,7 42.060185,31.062224 42.194833,60 47.881674,59.50527 53.925535,58.979939 53.958175,53.428766 54.060182,31.062224 54.120362,7 z"
+       inkscape:connector-curvature="0"
+       id="path5008"
+       style="opacity:0.5;fill:#3a240f;fill-opacity:1;display:inline" />
+    <path
+       d="m 41.6875,5.125 c 0.0042,-7.112e-4 -0.191651,0.032337 -0.1875,0.03125 0.0042,-0.00109 -0.160287,0.063954 -0.15625,0.0625 0.004,-0.00145 -0.160141,0.064309 -0.15625,0.0625 0.0039,-0.00181 -0.128713,0.06465 -0.125,0.0625 0.0037,-0.00215 -0.159756,0.096223 -0.15625,0.09375 0.0035,-0.00247 -0.128271,0.1277772 -0.125,0.125 0.0033,-0.00278 -0.128009,0.096809 -0.125,0.09375 0.003,-0.00306 -0.127724,0.1283156 -0.125,0.125 0.0027,-0.00332 -0.09617,0.1597959 -0.09375,0.15625 0.0024,-0.00355 -0.09584,0.1287479 -0.09375,0.125 0.0021,-0.00375 -0.06424,0.1601697 -0.0625,0.15625 0.0017,-0.00392 -0.06389,0.1603101 -0.0625,0.15625 0.0014,-0.00406 -0.03227,0.160418 -0.03125,0.15625 0.001,-0.00417 -0.06314,0.1604925 -0.0625,0.15625 6.42e-4,-0.00424 -2.6e-4,0.1917829 0,0.1875 2.08e-4,-0.00343 7.69e-4,0.08233 0,0.125 l 0,0.03125 L 40.1875,31.0625 40.3125,60 a 1.0057838,1.0057838 0 0 0 0,0.03125 c -4.2e-5,-0.0025 1.68e-4,0.0962 0,0.09375 -1.68e-4,-0.0025 2.94e-4,0.09619 0,0.09375 -2.94e-4,-0.0024 0.03167,0.09617 0.03125,0.09375 -4.19e-4,-0.0024 5.42e-4,0.09615 0,0.09375 -5.42e-4,-0.0024 0.03191,0.09611 0.03125,0.09375 -6.64e-4,-0.0024 0.03204,0.09608 0.03125,0.09375 -7.85e-4,-0.0023 0.03215,0.06479 0.03125,0.0625 -9.03e-4,-0.0023 0.03227,0.09599 0.03125,0.09375 -0.001,-0.0022 0.06363,0.09593 0.0625,0.09375 -0.0011,-0.0022 0.03249,0.09587 0.03125,0.09375 -0.0012,-0.0021 0.06385,0.06455 0.0625,0.0625 -0.0014,-0.0021 0.0327,0.09573 0.03125,0.09375 -0.0015,-0.002 0.06405,0.0644 0.0625,0.0625 -0.0016,-0.0019 0.06415,0.09557 0.0625,0.09375 -0.0016,-0.0018 0.06424,0.06423 0.0625,0.0625 -0.0017,-0.0017 0.09558,0.06414 0.09375,0.0625 -0.0018,-0.0016 0.06441,0.06405 0.0625,0.0625 -0.0019,-0.0015 0.06448,0.06395 0.0625,0.0625 -0.002,-0.0014 0.09581,0.06384 0.09375,0.0625 -0.0021,-0.0013 0.06462,0.03249 0.0625,0.03125 -0.0021,-0.0012 0.09593,0.06363 0.09375,0.0625 -0.0022,-0.0011 0.09599,0.03226 0.09375,0.03125 -0.0022,-0.001 0.09604,0.03215 0.09375,0.03125 -0.0023,-8.97e-4 0.09608,0.03203 0.09375,0.03125 -0.0023,-7.79e-4 0.09612,0.03191 0.09375,0.03125 -0.0024,-6.58e-4 0.09615,0.03179 0.09375,0.03125 -0.0024,-5.36e-4 0.09617,4.12e-4 0.09375,0 -0.0024,-4.12e-4 0.09619,0.03154 0.09375,0.03125 -0.0024,-2.88e-4 0.0962,1.62e-4 0.09375,0 -0.0025,-1.62e-4 0.09621,3.6e-5 0.09375,0 -0.0025,-3.6e-5 0.0962,-9e-5 0.09375,0 -0.0025,9e-5 0.0962,-2.16e-4 0.09375,0 l 5.6875,-0.5 6.03125,-0.53125 c -8.93e-4,5.1e-5 0.02019,0.0012 0.03125,0 0.04424,-0.0047 0.128538,-5.37e-4 0.125,0 -0.0044,6.71e-4 0.19184,-0.06358 0.1875,-0.0625 -0.0043,0.0011 0.160471,-0.03273 0.15625,-0.03125 -0.0042,0.0015 0.160314,-0.06437 0.15625,-0.0625 -0.0041,0.0019 0.160122,-0.09599 0.15625,-0.09375 -0.0039,0.0022 0.159897,-0.09634 0.15625,-0.09375 -0.0036,0.0026 0.128389,-0.09667 0.125,-0.09375 -0.0034,0.0029 0.128103,-0.128222 0.125,-0.125 -0.0031,0.0032 0.127789,-0.128497 0.125,-0.125 -0.0028,0.0035 0.0962,-0.159992 0.09375,-0.15625 -0.0025,0.0037 0.09584,-0.160204 0.09375,-0.15625 -0.0021,0.004 0.09546,-0.160382 0.09375,-0.15625 -0.0017,0.0041 0.06382,-0.160524 0.0625,-0.15625 -0.0013,0.0043 0.03217,-0.160628 0.03125,-0.15625 -9.16e-4,0.0044 0.03175,-0.191944 0.03125,-0.1875 -5.04e-4,0.0044 8.7e-5,-0.160722 0,-0.15625 a 1.0057838,1.0057838 0 0 0 0,-0.03125 L 55.84375,53.4375 55.9375,31.0625 56,7 c -7.3e-5,0.00479 -4.06e-4,-0.1610265 0,-0.15625 4.06e-4,0.00478 -0.03213,-0.1922121 -0.03125,-0.1875 8.81e-4,0.00471 -0.0326,-0.1921004 -0.03125,-0.1875 0.0013,0.0046 -0.0643,-0.1919427 -0.0625,-0.1875 0.0018,0.00444 -0.09599,-0.1604906 -0.09375,-0.15625 0.0022,0.00424 -0.0964,-0.160246 -0.09375,-0.15625 0.0026,0.004 -0.09678,-0.1599614 -0.09375,-0.15625 0.003,0.00371 -0.12839,-0.1596397 -0.125,-0.15625 0.0034,0.00339 -0.159961,-0.1280341 -0.15625,-0.125 0.0037,0.00303 -0.160246,-0.096398 -0.15625,-0.09375 0.004,0.00265 -0.160491,-0.095986 -0.15625,-0.09375 0.0042,0.00224 -0.160693,-0.095551 -0.15625,-0.09375 0.0044,0.0018 -0.1921,-0.063848 -0.1875,-0.0625 0.0046,0.00135 -0.192212,-0.032132 -0.1875,-0.03125 0.0047,8.815e-4 -0.192277,-0.031656 -0.1875,-0.03125 0.0048,4.063e-4 -0.161043,7.3e-5 -0.15625,0 l -12.03125,0 c 0.0026,2.364e-4 -0.04386,0.00229 -0.09375,0 -0.03326,-0.00153 -0.06424,0 -0.0625,0 0.0043,0 -0.19183,3.94e-4 -0.1875,0 a 1.0057838,1.0057838 0 0 0 -0.0625,0 z"
+       id="path3926"
+       style="opacity:0.1;fill:url(#linearGradient3934);fill-opacity:1;display:inline" />
+    <path
+       d="M 42,6.125 A 0.8619805,0.8619805 0 0 0 41.125,7 L 41.1875,31.0625 41.3125,60 a 0.8619805,0.8619805 0 0 0 0.9375,0.84375 l 5.6875,-0.5 L 54,59.8125 a 0.8619805,0.8619805 0 0 0 0.8125,-0.84375 L 54.84375,53.4375 54.9375,31.0625 55,7 A 0.8619805,0.8619805 0 0 0 54.125,6.125 L 42,6.125 z"
+       id="path3922"
+       style="opacity:0.2;fill:url(#linearGradient3942);fill-opacity:1;display:inline" />
+    <path
+       d="M 54.060184,4.3686547 48.000001,3.926713 41.939817,4.3686547 42.000001,30.062224 42.134649,59 l 5.686841,-0.494729 6.043862,-0.525332 0.03264,-5.551173 0.102006,-22.366542 0.06018,-25.6935693 z"
+       inkscape:connector-curvature="0"
+       id="polygon120"
+       style="fill:url(#linearGradient3277-4);fill-opacity:1;display:inline" />
+    <rect
+       width="1"
+       height="35.714287"
+       x="47"
+       y="4.1250005"
+       id="rect4363"
+       style="opacity:0.2;fill:#8d6137;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+    <rect
+       width="1"
+       height="35.714287"
+       x="48"
+       y="4.1250005"
+       id="rect4365"
+       style="opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+  </g>
+  <g
+     id="layer3" />
+  <g
+     id="layer5">
+    <g
+       transform="translate(0,-2)"
+       id="g3745"
+       style="display:inline">
+      <rect
+         width="14"
+         height="19"
+         rx="1.8666667"
+         ry="2"
+         x="15.5"
+         y="49.5"
+         id="rect3739"
+         style="fill:none;stroke:#825023;stroke-width:1;stroke-opacity:1" />
+      <path
+         d="m 18.25,66 0,-9.25 -1.25,0 2.5,-4.75 2.5,4.75 -1.25,0 0,9.25 -2.5,0 z"
+         inkscape:connector-curvature="0"
+         id="path3741"
+         style="fill:#825023;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 24.25,66 0,-9.25 -1.25,0 2.5,-4.75 2.5,4.75 -1.25,0 0,9.25 -2.5,0 z"
+         inkscape:connector-curvature="0"
+         id="path3743"
+         style="fill:#825023;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       id="text3750"
+       style="font-size:2px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#553417;fill-opacity:1;stroke:none;display:inline;font-family:Arial Black;-inkscape-font-specification:'Arial Black, Bold'">
+      <path
+         d="m 15.148438,74.082314 1.093749,0 0,0.307617 -0.649414,0 0,0.25 0.554688,0 0,0.289062 -0.554688,0 0,0.584961 -0.444335,0 0,-1.43164"
+         inkscape:connector-curvature="0"
+         id="path4168" />
+      <path
+         d="m 17.175781,75.277626 -0.503906,0 -0.06934,0.236328 -0.452148,0 0.538086,-1.43164 0.482421,0 0.538086,1.43164 -0.46289,0 -0.07031,-0.236328 m -0.09277,-0.30957 -0.158203,-0.514649 -0.157227,0.514649 0.31543,0"
+         inkscape:connector-curvature="0"
+         id="path4170" />
+      <path
+         d="m 17.848633,74.082314 1.185547,0 0,0.305664 -0.742188,0 0,0.227539 0.688477,0 0,0.291992 -0.688477,0 0,0.282226 0.763672,0 0,0.324219 -1.207031,0 0,-1.43164"
+         inkscape:connector-curvature="0"
+         id="path4172" />
+      <path
+         d="m 19.297852,74.082314 0.413085,0 0.539063,0.791992 0,-0.791992 0.416992,0 0,1.43164 -0.416992,0 -0.536133,-0.786133 0,0.786133 -0.416015,0 0,-1.43164"
+         inkscape:connector-curvature="0"
+         id="path4174" />
+      <path
+         d="m 20.926758,74.082314 1.251953,0 0,0.286132 -0.802734,0.837891 0.832031,0 0,0.307617 -1.358399,0 0,-0.296875 0.793946,-0.829101 -0.716797,0 0,-0.305664"
+         inkscape:connector-curvature="0"
+         id="path4176" />
+      <path
+         d="m 23.289062,75.277626 -0.503906,0 -0.06934,0.236328 -0.452148,0 0.538086,-1.43164 0.482422,0 0.538086,1.43164 -0.462891,0 -0.07031,-0.236328 m -0.09277,-0.30957 -0.158203,-0.514649 -0.157227,0.514649 0.31543,0"
+         inkscape:connector-curvature="0"
+         id="path4178" />
+    </g>
+    <g
+       id="text3754"
+       style="font-size:1.5px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#553417;fill-opacity:1;stroke:none;display:inline;font-family:Arial;-inkscape-font-specification:Arial">
+      <path
+         d="m 15.109863,81.513954 0,-1.07373 0.14209,0 0,0.53247 0.533203,-0.53247 0.192627,0 -0.450439,0.435058 0.470215,0.638672 -0.1875,0 -0.382325,-0.543457 -0.175781,0.171387 0,0.37207 -0.14209,0"
+         inkscape:connector-curvature="0"
+         id="path4067" />
+      <path
+         d="m 16.633301,81.263466 0.13623,0.01685 c -0.02149,0.07959 -0.06128,0.141357 -0.119385,0.185302 -0.05811,0.04395 -0.132324,0.06592 -0.222656,0.06592 -0.11377,0 -0.204102,-0.03491 -0.270996,-0.104736 -0.06641,-0.07031 -0.09961,-0.168701 -0.09961,-0.295166 0,-0.130859 0.03369,-0.232421 0.101074,-0.304688 0.06738,-0.07226 0.154785,-0.108397 0.262207,-0.108398 0.104003,1e-6 0.188964,0.0354 0.254883,0.106201 0.06592,0.0708 0.09888,0.170411 0.09888,0.298828 -1e-6,0.0078 -2.45e-4,0.01953 -7.33e-4,0.03516 l -0.580078,0 c 0.0049,0.08545 0.02905,0.150879 0.07251,0.196289 0.04346,0.04541 0.09766,0.06812 0.162598,0.06812 0.04834,0 0.0896,-0.0127 0.123779,-0.03809 0.03418,-0.02539 0.06128,-0.06592 0.0813,-0.121582 m -0.432862,-0.213135 0.434327,0 c -0.0059,-0.06543 -0.02246,-0.114501 -0.0498,-0.147217 -0.04199,-0.05078 -0.09644,-0.07617 -0.16333,-0.07617 -0.06055,10e-7 -0.111573,0.02026 -0.153076,0.06079 -0.04102,0.04053 -0.06372,0.09473 -0.06812,0.162598"
+         inkscape:connector-curvature="0"
+         id="path4069" />
+      <path
+         d="m 17.468262,81.263466 0.13623,0.01685 c -0.02149,0.07959 -0.06128,0.141357 -0.119385,0.185302 -0.05811,0.04395 -0.132324,0.06592 -0.222656,0.06592 -0.11377,0 -0.204102,-0.03491 -0.270996,-0.104736 -0.06641,-0.07031 -0.09961,-0.168701 -0.09961,-0.295166 0,-0.130859 0.03369,-0.232421 0.101074,-0.304688 0.06738,-0.07226 0.154785,-0.108397 0.262207,-0.108398 0.104003,1e-6 0.188964,0.0354 0.254883,0.106201 0.06592,0.0708 0.09888,0.170411 0.09888,0.298828 -1e-6,0.0078 -2.45e-4,0.01953 -7.33e-4,0.03516 l -0.580078,0 c 0.0049,0.08545 0.02905,0.150879 0.07251,0.196289 0.04346,0.04541 0.09766,0.06812 0.162598,0.06812 0.04834,0 0.0896,-0.0127 0.123779,-0.03809 0.03418,-0.02539 0.06128,-0.06592 0.0813,-0.121582 m -0.432862,-0.213135 0.434327,0 c -0.0059,-0.06543 -0.02246,-0.114501 -0.0498,-0.147217 -0.04199,-0.05078 -0.09644,-0.07617 -0.16333,-0.07617 -0.06055,10e-7 -0.111573,0.02026 -0.153076,0.06079 -0.04102,0.04053 -0.06372,0.09473 -0.06812,0.162598"
+         inkscape:connector-curvature="0"
+         id="path4071" />
+      <path
+         d="m 17.770752,81.81205 0,-1.075928 0.120117,0 0,0.101074 c 0.02832,-0.03955 0.0603,-0.06909 0.09595,-0.08862 0.03564,-0.02002 0.07886,-0.03003 0.129639,-0.03003 0.06641,10e-7 0.125,0.01709 0.175781,0.05127 0.05078,0.03418 0.08911,0.08252 0.114991,0.145019 0.02588,0.06201 0.03882,0.130127 0.03882,0.204346 -1e-6,0.07959 -0.01441,0.151367 -0.04321,0.215332 -0.02832,0.06348 -0.06983,0.112305 -0.124512,0.146484 -0.0542,0.03369 -0.111328,0.05054 -0.171386,0.05054 -0.04395,0 -0.0835,-0.0093 -0.118653,-0.02783 -0.03467,-0.01855 -0.06323,-0.04199 -0.08569,-0.07031 l 0,0.378662 -0.131836,0 m 0.119385,-0.682617 c 0,0.100098 0.02026,0.174072 0.06079,0.221924 0.04053,0.04785 0.0896,0.07178 0.147217,0.07178 0.05859,0 0.108642,-0.02466 0.150146,-0.07398 0.04199,-0.0498 0.06299,-0.126708 0.06299,-0.230713 0,-0.09912 -0.02051,-0.173339 -0.06152,-0.222656 -0.04053,-0.04932 -0.08911,-0.07397 -0.145752,-0.07398 -0.05615,10e-7 -0.105957,0.02637 -0.149414,0.0791 -0.04297,0.05225 -0.06445,0.128419 -0.06445,0.228516"
+         inkscape:connector-curvature="0"
+         id="path4073" />
+      <path
+         d="m 19.022461,80.591835 0,-0.151611 0.131836,0 0,0.151611 -0.131836,0 m 0,0.922119 0,-0.777832 0.131836,0 0,0.777832 -0.131836,0"
+         inkscape:connector-curvature="0"
+         id="path4075" />
+      <path
+         d="m 19.355713,81.513954 0,-0.777832 0.118652,0 0,0.110596 c 0.05713,-0.08545 0.139648,-0.128173 0.247559,-0.128174 0.04687,1e-6 0.08984,0.0085 0.128906,0.02564 0.03955,0.0166 0.06909,0.03857 0.08862,0.06592 0.01953,0.02734 0.0332,0.05982 0.04102,0.09741 0.0049,0.02441 0.0073,0.06714 0.0073,0.128174 l 0,0.478271 -0.131836,0 0,-0.473144 c -1e-6,-0.05371 -0.0051,-0.09375 -0.01538,-0.120118 -0.01025,-0.02685 -0.02857,-0.0481 -0.05493,-0.06372 -0.02588,-0.01611 -0.0564,-0.02417 -0.09155,-0.02417 -0.05615,0 -0.104737,0.01782 -0.145752,0.05347 -0.04053,0.03565 -0.06079,0.103272 -0.06079,0.20288 l 0,0.424805 -0.131836,0"
+         inkscape:connector-curvature="0"
+         id="path4077" />
+      <path
+         d="m 21.114258,81.418007 c -0.04883,0.0415 -0.09595,0.0708 -0.141358,0.08789 -0.04492,0.01709 -0.09326,0.02563 -0.145019,0.02563 -0.08545,0 -0.151123,-0.02075 -0.197022,-0.06226 -0.0459,-0.04199 -0.06885,-0.09546 -0.06885,-0.1604 0,-0.03809 0.0085,-0.07275 0.02563,-0.104004 0.01758,-0.03174 0.04028,-0.05713 0.06812,-0.07617 0.02832,-0.01904 0.06006,-0.03345 0.09521,-0.04321 0.02588,-0.0068 0.06494,-0.01343 0.117187,-0.01977 0.106445,-0.0127 0.184814,-0.02783 0.235107,-0.04541 4.88e-4,-0.01807 7.32e-4,-0.02954 7.33e-4,-0.03442 -10e-7,-0.05371 -0.01245,-0.09155 -0.03735,-0.113525 -0.03369,-0.02979 -0.08374,-0.04468 -0.150146,-0.04468 -0.06201,10e-7 -0.107911,0.01099 -0.137695,0.03296 -0.0293,0.02148 -0.05103,0.05982 -0.06519,0.11499 l -0.128906,-0.01758 c 0.01172,-0.05517 0.03101,-0.09961 0.05786,-0.133301 0.02686,-0.03418 0.06567,-0.0603 0.116455,-0.07837 0.05078,-0.01855 0.109619,-0.02783 0.176514,-0.02783 0.06641,10e-7 0.120361,0.0078 0.161865,0.02344 0.0415,0.01563 0.07202,0.0354 0.09155,0.05933 0.01953,0.02344 0.0332,0.05322 0.04102,0.08935 0.0044,0.02246 0.0066,0.06299 0.0066,0.121582 l 0,0.175781 c 0,0.122559 0.0027,0.200196 0.0081,0.232911 0.0059,0.03223 0.01709,0.06323 0.03369,0.09302 l -0.137695,0 c -0.01367,-0.02734 -0.02246,-0.05933 -0.02637,-0.09595 m -0.01099,-0.294434 c -0.04785,0.01953 -0.119629,0.03613 -0.215332,0.04981 -0.0542,0.0078 -0.09253,0.0166 -0.11499,0.02637 -0.02246,0.0098 -0.0398,0.02417 -0.052,0.04321 -0.01221,0.01855 -0.01831,0.03931 -0.01831,0.06226 0,0.03516 0.01318,0.06445 0.03955,0.08789 0.02686,0.02344 0.06592,0.03516 0.117188,0.03516 0.05078,0 0.09595,-0.01099 0.135498,-0.03296 0.03955,-0.02246 0.0686,-0.05298 0.08716,-0.09155 0.01416,-0.02978 0.02124,-0.07373 0.02124,-0.131836 l 0,-0.04834"
+         inkscape:connector-curvature="0"
+         id="path4079" />
+      <path
+         d="m 21.804932,81.281776 0.130371,-0.02051 c 0.0073,0.05225 0.02759,0.09229 0.06079,0.120117 0.03369,0.02783 0.08057,0.04175 0.140625,0.04175 0.06055,0 0.105468,-0.01221 0.134765,-0.03662 0.0293,-0.0249 0.04395,-0.05395 0.04395,-0.08716 -10e-7,-0.02979 -0.01294,-0.05322 -0.03882,-0.07031 -0.01807,-0.01172 -0.06299,-0.02661 -0.134765,-0.04468 -0.09668,-0.02441 -0.163819,-0.04541 -0.201416,-0.06299 -0.03711,-0.01807 -0.06543,-0.04272 -0.08496,-0.07398 -0.01904,-0.03174 -0.02857,-0.06665 -0.02857,-0.104736 0,-0.03467 0.0078,-0.06665 0.02344,-0.09595 0.01611,-0.02978 0.03784,-0.05444 0.06518,-0.07397 0.02051,-0.01514 0.04834,-0.02783 0.0835,-0.03809 0.03564,-0.01074 0.07373,-0.01611 0.114258,-0.01611 0.06104,10e-7 0.114502,0.0088 0.160401,0.02637 0.04639,0.01758 0.08057,0.04151 0.102539,0.07178 0.02197,0.02979 0.03711,0.06982 0.04541,0.120117 l -0.128906,0.01758 c -0.0059,-0.04004 -0.02295,-0.07129 -0.05127,-0.09375 -0.02783,-0.02246 -0.06738,-0.03369 -0.118652,-0.03369 -0.06055,10e-7 -0.10376,0.01001 -0.129639,0.03003 -0.02588,0.02002 -0.03882,0.04346 -0.03882,0.07031 0,0.01709 0.0054,0.03247 0.01611,0.04614 0.01074,0.01416 0.02759,0.02588 0.05054,0.03516 0.01318,0.0049 0.052,0.01611 0.116455,0.03369 0.09326,0.0249 0.158203,0.04541 0.194824,0.06152 0.03711,0.01563 0.06616,0.03858 0.08716,0.06885 0.021,0.03027 0.03149,0.06787 0.03149,0.112793 -10e-7,0.04395 -0.01294,0.08545 -0.03882,0.124511 -0.02539,0.03858 -0.06226,0.0686 -0.110595,0.09009 -0.04834,0.021 -0.103028,0.03149 -0.164063,0.03149 -0.101074,0 -0.178223,-0.021 -0.231445,-0.06299 -0.05274,-0.04199 -0.08643,-0.104248 -0.101074,-0.186768"
+         inkscape:connector-curvature="0"
+         id="path4081" />
+      <path
+         d="m 23.115234,81.418007 c -0.04883,0.0415 -0.09595,0.0708 -0.141357,0.08789 -0.04492,0.01709 -0.09326,0.02563 -0.14502,0.02563 -0.08545,0 -0.151123,-0.02075 -0.197021,-0.06226 -0.0459,-0.04199 -0.06885,-0.09546 -0.06885,-0.1604 0,-0.03809 0.0085,-0.07275 0.02563,-0.104004 0.01758,-0.03174 0.04028,-0.05713 0.06812,-0.07617 0.02832,-0.01904 0.06006,-0.03345 0.09521,-0.04321 0.02588,-0.0068 0.06494,-0.01343 0.117188,-0.01977 0.106444,-0.0127 0.184814,-0.02783 0.235107,-0.04541 4.88e-4,-0.01807 7.32e-4,-0.02954 7.32e-4,-0.03442 0,-0.05371 -0.01245,-0.09155 -0.03735,-0.113525 -0.03369,-0.02979 -0.08374,-0.04468 -0.150147,-0.04468 -0.06201,10e-7 -0.10791,0.01099 -0.137695,0.03296 -0.0293,0.02148 -0.05102,0.05982 -0.06518,0.11499 l -0.128907,-0.01758 c 0.01172,-0.05517 0.03101,-0.09961 0.05786,-0.133301 0.02686,-0.03418 0.06567,-0.0603 0.116455,-0.07837 0.05078,-0.01855 0.109619,-0.02783 0.176513,-0.02783 0.06641,10e-7 0.120361,0.0078 0.161866,0.02344 0.0415,0.01563 0.07202,0.0354 0.09155,0.05933 0.01953,0.02344 0.0332,0.05322 0.04102,0.08935 0.0044,0.02246 0.0066,0.06299 0.0066,0.121582 l 0,0.175781 c -1e-6,0.122559 0.0027,0.200196 0.0081,0.232911 0.0059,0.03223 0.01709,0.06323 0.03369,0.09302 l -0.137695,0 c -0.01367,-0.02734 -0.02246,-0.05933 -0.02637,-0.09595 m -0.01099,-0.294434 c -0.04785,0.01953 -0.119629,0.03613 -0.215332,0.04981 -0.0542,0.0078 -0.09253,0.0166 -0.11499,0.02637 -0.02246,0.0098 -0.03979,0.02417 -0.052,0.04321 -0.01221,0.01855 -0.01831,0.03931 -0.01831,0.06226 0,0.03516 0.01318,0.06445 0.03955,0.08789 0.02686,0.02344 0.06592,0.03516 0.117188,0.03516 0.05078,0 0.09595,-0.01099 0.135498,-0.03296 0.03955,-0.02246 0.0686,-0.05298 0.08716,-0.09155 0.01416,-0.02978 0.02124,-0.07373 0.02124,-0.131836 l 0,-0.04834"
+         inkscape:connector-curvature="0"
+         id="path4083" />
+      <path
+         d="m 23.474121,81.513954 0,-0.675293 -0.116455,0 0,-0.102539 0.116455,0 0,-0.08276 c 0,-0.05224 0.0046,-0.09106 0.01392,-0.116455 0.0127,-0.03418 0.03491,-0.06177 0.06665,-0.08276 0.03223,-0.02148 0.07715,-0.03223 0.134766,-0.03223 0.03711,1e-6 0.07813,0.0044 0.123047,0.01318 l -0.01977,0.11499 c -0.02735,-0.0049 -0.05322,-0.0073 -0.07764,-0.0073 -0.04004,10e-7 -0.06836,0.0085 -0.08496,0.02564 -0.0166,0.01709 -0.0249,0.04907 -0.0249,0.09595 l 0,0.07178 0.151611,0 0,0.102539 -0.151611,0 0,0.675293 -0.131104,0"
+         inkscape:connector-curvature="0"
+         id="path4085" />
+      <path
+         d="m 24.391113,81.263466 0.136231,0.01685 c -0.02148,0.07959 -0.06128,0.141357 -0.119385,0.185302 -0.05811,0.04395 -0.132325,0.06592 -0.222656,0.06592 -0.11377,0 -0.204102,-0.03491 -0.270996,-0.104736 -0.06641,-0.07031 -0.09961,-0.168701 -0.09961,-0.295166 0,-0.130859 0.03369,-0.232421 0.101074,-0.304688 0.06738,-0.07226 0.154785,-0.108397 0.262208,-0.108398 0.104003,1e-6 0.188964,0.0354 0.254882,0.106201 0.06592,0.0708 0.09888,0.170411 0.09888,0.298828 0,0.0078 -2.45e-4,0.01953 -7.32e-4,0.03516 l -0.580078,0 c 0.0049,0.08545 0.02905,0.150879 0.07251,0.196289 0.04346,0.04541 0.09766,0.06812 0.162598,0.06812 0.04834,0 0.0896,-0.0127 0.123779,-0.03809 0.03418,-0.02539 0.06128,-0.06592 0.0813,-0.121582 m -0.432861,-0.213135 0.434326,0 c -0.0059,-0.06543 -0.02246,-0.114501 -0.0498,-0.147217 -0.04199,-0.05078 -0.09644,-0.07617 -0.16333,-0.07617 -0.06055,10e-7 -0.111572,0.02026 -0.153076,0.06079 -0.04102,0.04053 -0.06372,0.09473 -0.06811,0.162598"
+         inkscape:connector-curvature="0"
+         id="path4087" />
+      <path
+         d="m 25.109619,81.81205 0,-1.075928 0.120117,0 0,0.101074 c 0.02832,-0.03955 0.0603,-0.06909 0.09595,-0.08862 0.03564,-0.02002 0.07886,-0.03003 0.129638,-0.03003 0.06641,10e-7 0.125,0.01709 0.175782,0.05127 0.05078,0.03418 0.08911,0.08252 0.11499,0.145019 0.02588,0.06201 0.03882,0.130127 0.03882,0.204346 -10e-7,0.07959 -0.01441,0.151367 -0.04321,0.215332 -0.02832,0.06348 -0.06983,0.112305 -0.124512,0.146484 -0.0542,0.03369 -0.111328,0.05054 -0.171386,0.05054 -0.04395,0 -0.0835,-0.0093 -0.118653,-0.02783 -0.03467,-0.01855 -0.06323,-0.04199 -0.08569,-0.07031 l 0,0.378662 -0.131836,0 m 0.119385,-0.682617 c 0,0.100098 0.02026,0.174072 0.06079,0.221924 0.04053,0.04785 0.0896,0.07178 0.147217,0.07178 0.05859,0 0.108642,-0.02466 0.150146,-0.07398 0.04199,-0.0498 0.06299,-0.126708 0.06299,-0.230713 0,-0.09912 -0.02051,-0.173339 -0.06152,-0.222656 -0.04053,-0.04932 -0.08911,-0.07397 -0.145752,-0.07398 -0.05615,10e-7 -0.105957,0.02637 -0.149414,0.0791 -0.04297,0.05225 -0.06445,0.128419 -0.06445,0.228516"
+         inkscape:connector-curvature="0"
+         id="path4089" />
+      <path
+         d="m 25.94165,81.513954 0,-1.07373 0.131836,0 0,1.07373 -0.131836,0"
+         inkscape:connector-curvature="0"
+         id="path4091" />
+      <path
+         d="m 26.786133,81.418007 c -0.04883,0.0415 -0.09595,0.0708 -0.141358,0.08789 -0.04492,0.01709 -0.09326,0.02563 -0.145019,0.02563 -0.08545,0 -0.151123,-0.02075 -0.197022,-0.06226 -0.0459,-0.04199 -0.06885,-0.09546 -0.06885,-0.1604 0,-0.03809 0.0085,-0.07275 0.02563,-0.104004 0.01758,-0.03174 0.04028,-0.05713 0.06812,-0.07617 0.02832,-0.01904 0.06006,-0.03345 0.09521,-0.04321 0.02588,-0.0068 0.06494,-0.01343 0.117187,-0.01977 0.106445,-0.0127 0.184814,-0.02783 0.235107,-0.04541 4.88e-4,-0.01807 7.32e-4,-0.02954 7.33e-4,-0.03442 -10e-7,-0.05371 -0.01245,-0.09155 -0.03735,-0.113525 -0.03369,-0.02979 -0.08374,-0.04468 -0.150146,-0.04468 -0.06201,10e-7 -0.107911,0.01099 -0.137695,0.03296 -0.0293,0.02148 -0.05103,0.05982 -0.06519,0.11499 l -0.128906,-0.01758 c 0.01172,-0.05517 0.03101,-0.09961 0.05786,-0.133301 0.02686,-0.03418 0.06567,-0.0603 0.116455,-0.07837 0.05078,-0.01855 0.109619,-0.02783 0.176514,-0.02783 0.06641,10e-7 0.120361,0.0078 0.161865,0.02344 0.0415,0.01563 0.07202,0.0354 0.09155,0.05933 0.01953,0.02344 0.0332,0.05322 0.04102,0.08935 0.0044,0.02246 0.0066,0.06299 0.0066,0.121582 l 0,0.175781 c 0,0.122559 0.0027,0.200196 0.0081,0.232911 0.0059,0.03223 0.01709,0.06323 0.03369,0.09302 l -0.137695,0 c -0.01367,-0.02734 -0.02246,-0.05933 -0.02637,-0.09595 m -0.01099,-0.294434 c -0.04785,0.01953 -0.119629,0.03613 -0.215332,0.04981 -0.0542,0.0078 -0.09253,0.0166 -0.11499,0.02637 -0.02246,0.0098 -0.0398,0.02417 -0.052,0.04321 -0.01221,0.01855 -0.01831,0.03931 -0.01831,0.06226 0,0.03516 0.01318,0.06445 0.03955,0.08789 0.02686,0.02344 0.06592,0.03516 0.117188,0.03516 0.05078,0 0.09595,-0.01099 0.135498,-0.03296 0.03955,-0.02246 0.0686,-0.05298 0.08716,-0.09155 0.01416,-0.02978 0.02124,-0.07373 0.02124,-0.131836 l 0,-0.04834"
+         inkscape:connector-curvature="0"
+         id="path4093" />
+      <path
+         d="m 27.621094,81.229042 0.129638,0.01685 c -0.01416,0.08936 -0.05054,0.159424 -0.10913,0.210205 -0.05811,0.05029 -0.12964,0.07544 -0.2146,0.07544 -0.106446,0 -0.192139,-0.03467 -0.25708,-0.104004 -0.06445,-0.06982 -0.09668,-0.169677 -0.09668,-0.29956 0,-0.08398 0.01392,-0.15747 0.04175,-0.220459 0.02783,-0.06299 0.07007,-0.110107 0.126709,-0.141358 0.05713,-0.03174 0.11914,-0.04761 0.186035,-0.04761 0.08447,10e-7 0.153564,0.02149 0.207276,0.06445 0.05371,0.04248 0.08813,0.103028 0.103271,0.181641 l -0.128174,0.01978 c -0.01221,-0.05224 -0.03394,-0.09155 -0.06518,-0.11792 -0.03076,-0.02637 -0.06812,-0.03955 -0.112061,-0.03955 -0.06641,10e-7 -0.120361,0.02393 -0.161865,0.07178 -0.0415,0.04736 -0.06226,0.122559 -0.06226,0.225586 0,0.104492 0.02002,0.18042 0.06006,0.227783 0.04004,0.04736 0.09229,0.07104 0.156738,0.07104 0.05176,0 0.09497,-0.01587 0.129639,-0.04761 0.03467,-0.03174 0.05664,-0.08057 0.06592,-0.146484"
+         inkscape:connector-curvature="0"
+         id="path4095" />
+      <path
+         d="m 28.395996,81.263466 0.136231,0.01685 c -0.02149,0.07959 -0.06128,0.141357 -0.119385,0.185302 -0.05811,0.04395 -0.132325,0.06592 -0.222656,0.06592 -0.11377,0 -0.204102,-0.03491 -0.270997,-0.104736 -0.06641,-0.07031 -0.09961,-0.168701 -0.09961,-0.295166 0,-0.130859 0.03369,-0.232421 0.101074,-0.304688 0.06738,-0.07226 0.154785,-0.108397 0.262207,-0.108398 0.104004,1e-6 0.188965,0.0354 0.254883,0.106201 0.06592,0.0708 0.09888,0.170411 0.09888,0.298828 -10e-7,0.0078 -2.45e-4,0.01953 -7.32e-4,0.03516 l -0.580078,0 c 0.0049,0.08545 0.02905,0.150879 0.07251,0.196289 0.04346,0.04541 0.09766,0.06812 0.162598,0.06812 0.04834,0 0.0896,-0.0127 0.123779,-0.03809 0.03418,-0.02539 0.06128,-0.06592 0.0813,-0.121582 m -0.432861,-0.213135 0.434326,0 c -0.0059,-0.06543 -0.02246,-0.114501 -0.0498,-0.147217 -0.04199,-0.05078 -0.09644,-0.07617 -0.16333,-0.07617 -0.06055,10e-7 -0.111572,0.02026 -0.153076,0.06079 -0.04102,0.04053 -0.06372,0.09473 -0.06811,0.162598"
+         inkscape:connector-curvature="0"
+         id="path4098" />
+      <path
+         d="m 16.077393,83.388954 -0.23584,0 -0.09375,-0.243896 -0.429199,0 -0.08862,0.243896 -0.22998,0 0.418213,-1.07373 0.229248,0 0.429932,1.07373 m -0.39917,-0.424805 -0.14795,-0.398437 -0.145019,0.398437 0.292969,0"
+         inkscape:connector-curvature="0"
+         id="path4100"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 16.905029,83.388954 -0.191162,0 0,-0.114258 c -0.03174,0.04443 -0.06934,0.07764 -0.112793,0.09961 -0.04297,0.02148 -0.08643,0.03223 -0.130371,0.03223 -0.08936,0 -0.166016,-0.03589 -0.22998,-0.107666 -0.06348,-0.07227 -0.09521,-0.172851 -0.09521,-0.301758 0,-0.131835 0.03101,-0.231933 0.09302,-0.300293 0.06201,-0.06885 0.140381,-0.10327 0.235108,-0.103271 0.08691,10e-7 0.162109,0.03613 0.225586,0.108398 l 0,-0.386718 0.20581,0 0,1.07373 m -0.549316,-0.405762 c 0,0.08301 0.01147,0.143067 0.03442,0.180176 0.0332,0.05371 0.07959,0.08057 0.13916,0.08057 0.04736,0 0.08765,-0.02002 0.120849,-0.06006 0.0332,-0.04053 0.0498,-0.10083 0.0498,-0.180908 0,-0.08935 -0.01611,-0.153564 -0.04834,-0.192627 -0.03223,-0.03955 -0.07349,-0.05933 -0.123779,-0.05933 -0.04883,0 -0.08984,0.01953 -0.123047,0.05859 -0.03271,0.03858 -0.04907,0.09644 -0.04907,0.173584"
+         inkscape:connector-curvature="0"
+         id="path4102"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 17.093262,82.611122 0.189697,0 0,0.106201 c 0.06787,-0.08252 0.148681,-0.123778 0.242432,-0.123779 0.0498,1e-6 0.09302,0.01026 0.129638,0.03076 0.03662,0.02051 0.06665,0.05151 0.09009,0.09302 0.03418,-0.0415 0.07104,-0.07251 0.110596,-0.09302 0.03955,-0.02051 0.08179,-0.03076 0.126709,-0.03076 0.05713,1e-6 0.105468,0.01172 0.145019,0.03516 0.03955,0.02295 0.06909,0.05689 0.08862,0.101807 0.01416,0.0332 0.02124,0.08691 0.02124,0.161133 l 0,0.497314 -0.205811,0 0,-0.44458 c -1e-6,-0.07715 -0.0071,-0.126952 -0.02124,-0.149414 -0.01904,-0.0293 -0.04834,-0.04395 -0.08789,-0.04395 -0.02881,0 -0.05591,0.0088 -0.0813,0.02637 -0.02539,0.01758 -0.0437,0.04346 -0.05493,0.07764 -0.01123,0.03369 -0.01685,0.08716 -0.01685,0.1604 l 0,0.373535 -0.20581,0 0,-0.426269 c -1e-6,-0.07568 -0.0037,-0.124512 -0.01099,-0.146485 -0.0073,-0.02197 -0.0188,-0.03833 -0.03442,-0.04907 -0.01514,-0.01074 -0.03589,-0.01611 -0.06226,-0.01611 -0.03174,0 -0.0603,0.0085 -0.08569,0.02563 -0.02539,0.01709 -0.0437,0.04175 -0.05493,0.07397 -0.01074,0.03223 -0.01611,0.08569 -0.01611,0.1604 l 0,0.37793 -0.20581,0 0,-0.777832"
+         inkscape:connector-curvature="0"
+         id="path4104"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 18.44165,82.505653 0,-0.190429 0.205811,0 0,0.190429 -0.205811,0 m 0,0.883301 0,-0.777832 0.205811,0 0,0.777832 -0.205811,0"
+         inkscape:connector-curvature="0"
+         id="path4106"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 19.565186,83.388954 -0.205811,0 0,-0.396972 c -1e-6,-0.08398 -0.0044,-0.138184 -0.01318,-0.162598 -0.0088,-0.0249 -0.02319,-0.04419 -0.04321,-0.05786 -0.01953,-0.01367 -0.04321,-0.02051 -0.07105,-0.02051 -0.03564,0 -0.06763,0.0098 -0.09595,0.0293 -0.02832,0.01953 -0.04785,0.04541 -0.05859,0.07764 -0.01026,0.03223 -0.01538,0.0918 -0.01538,0.178711 l 0,0.352295 -0.205811,0 0,-0.777832 0.191162,0 0,0.114258 c 0.06787,-0.08789 0.15332,-0.131835 0.256348,-0.131836 0.04541,1e-6 0.08691,0.0083 0.124512,0.0249 0.0376,0.01611 0.06592,0.03687 0.08496,0.06226 0.01953,0.02539 0.03296,0.0542 0.04028,0.08643 0.0078,0.03223 0.01172,0.07837 0.01172,0.138428 l 0,0.483398"
+         inkscape:connector-curvature="0"
+         id="path4108"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 19.774658,82.505653 0,-0.190429 0.205811,0 0,0.190429 -0.205811,0 m 0,0.883301 0,-0.777832 0.205811,0 0,0.777832 -0.205811,0"
+         inkscape:connector-curvature="0"
+         id="path4110"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 20.118164,83.16703 0.206543,-0.03149 c 0.0088,0.04004 0.02661,0.07056 0.05347,0.09155 0.02685,0.02051 0.06445,0.03076 0.112793,0.03076 0.05322,0 0.09326,-0.0098 0.120117,-0.0293 0.01807,-0.01367 0.0271,-0.03198 0.0271,-0.05493 -10e-7,-0.01563 -0.0049,-0.02856 -0.01465,-0.03882 -0.01025,-0.0098 -0.0332,-0.0188 -0.06885,-0.0271 -0.166015,-0.03662 -0.27124,-0.07007 -0.315673,-0.100342 -0.06152,-0.04199 -0.09229,-0.100341 -0.09229,-0.175048 -10e-7,-0.06738 0.02661,-0.124023 0.07983,-0.169922 0.05322,-0.0459 0.135742,-0.06885 0.247559,-0.06885 0.106445,1e-6 0.185546,0.01734 0.237305,0.052 0.05176,0.03467 0.0874,0.08594 0.106933,0.153809 l -0.194091,0.03589 c -0.0083,-0.03027 -0.02417,-0.05347 -0.04761,-0.06958 -0.02295,-0.01611 -0.05591,-0.02417 -0.09888,-0.02417 -0.0542,10e-7 -0.09302,0.0076 -0.116455,0.0227 -0.01563,0.01074 -0.02344,0.02466 -0.02344,0.04175 -1e-6,0.01465 0.0068,0.0271 0.02051,0.03735 0.01855,0.01367 0.08252,0.03296 0.191895,0.05786 0.109863,0.0249 0.186523,0.05542 0.22998,0.09155 0.04297,0.03662 0.06445,0.08765 0.06445,0.153076 -10e-7,0.07129 -0.02979,0.132569 -0.08936,0.183838 -0.05957,0.05127 -0.147706,0.0769 -0.264404,0.0769 -0.105958,0 -0.189942,-0.02148 -0.251953,-0.06445 -0.06152,-0.04297 -0.101807,-0.101318 -0.12085,-0.175049"
+         inkscape:connector-curvature="0"
+         id="path4112"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 21.382324,82.611122 0,0.164063 -0.140625,0 0,0.313476 c 0,0.06348 0.0012,0.100586 0.0037,0.111328 0.0029,0.01025 0.009,0.0188 0.01831,0.02563 0.0098,0.0068 0.02148,0.01025 0.03516,0.01025 0.01904,0 0.04663,-0.0066 0.08276,-0.01977 l 0.01758,0.159668 c -0.04785,0.02051 -0.102051,0.03076 -0.162598,0.03076 -0.03711,0 -0.07056,-0.0061 -0.100342,-0.01831 -0.02979,-0.0127 -0.05176,-0.02881 -0.06592,-0.04834 -0.01367,-0.02002 -0.02319,-0.04687 -0.02856,-0.08057 -0.0044,-0.02393 -0.0066,-0.07227 -0.0066,-0.145019 l 0,-0.339111 -0.09448,0 0,-0.164063 0.09448,0 0,-0.154541 0.206543,-0.120117 0,0.274658 0.140625,0"
+         inkscape:connector-curvature="0"
+         id="path4114"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 21.723633,83.388954 -0.205811,0 0,-0.777832 0.191162,0 0,0.110596 c 0.03271,-0.05225 0.06201,-0.08667 0.08789,-0.103272 0.02637,-0.0166 0.05615,-0.0249 0.08936,-0.0249 0.04687,10e-7 0.09204,0.01294 0.135499,0.03882 l -0.06372,0.179444 c -0.03467,-0.02246 -0.06689,-0.03369 -0.09668,-0.03369 -0.02881,10e-7 -0.05322,0.0081 -0.07324,0.02417 -0.02002,0.01563 -0.03589,0.04419 -0.04761,0.08569 -0.01123,0.0415 -0.01685,0.128418 -0.01685,0.260742 l 0,0.240234"
+         inkscape:connector-curvature="0"
+         id="path4116"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 22.263428,82.848427 -0.186768,-0.03369 c 0.021,-0.07519 0.05713,-0.130858 0.108399,-0.166992 0.05127,-0.03613 0.127441,-0.0542 0.228515,-0.0542 0.0918,10e-7 0.160156,0.01099 0.205078,0.03296 0.04492,0.02148 0.07642,0.04907 0.09448,0.08276 0.01855,0.0332 0.02783,0.09448 0.02783,0.183838 l -0.0022,0.240234 c -1e-6,0.06836 0.0032,0.118897 0.0095,0.151611 0.0068,0.03223 0.01929,0.0669 0.03735,0.104004 l -0.203614,0 c -0.0054,-0.01367 -0.01196,-0.03393 -0.01977,-0.06079 -0.0034,-0.01221 -0.0059,-0.02026 -0.0073,-0.02417 -0.03516,0.03418 -0.07276,0.05982 -0.112793,0.0769 -0.04004,0.01709 -0.08276,0.02563 -0.128174,0.02563 -0.08008,0 -0.143311,-0.02173 -0.189697,-0.06518 -0.0459,-0.04346 -0.06885,-0.09839 -0.06885,-0.164795 0,-0.04395 0.0105,-0.08301 0.03149,-0.117188 0.021,-0.03467 0.05029,-0.06103 0.08789,-0.0791 0.03809,-0.01855 0.09277,-0.03467 0.164062,-0.04834 0.09619,-0.01807 0.162841,-0.03491 0.199951,-0.05054 l 0,-0.02051 c 0,-0.03955 -0.0098,-0.06763 -0.0293,-0.08423 -0.01953,-0.01709 -0.0564,-0.02563 -0.110595,-0.02563 -0.03662,0 -0.06519,0.0073 -0.08569,0.02197 -0.02051,0.01416 -0.03711,0.03931 -0.0498,0.07544 m 0.27539,0.166992 c -0.02637,0.0088 -0.06811,0.01929 -0.125244,0.03149 -0.05713,0.01221 -0.09448,0.02417 -0.11206,0.03589 -0.02686,0.01904 -0.04028,0.04321 -0.04028,0.07251 0,0.02881 0.01074,0.05371 0.03223,0.07471 0.02148,0.021 0.04883,0.03149 0.08203,0.03149 0.03711,0 0.07251,-0.01221 0.106201,-0.03662 0.0249,-0.01855 0.04126,-0.04126 0.04907,-0.06812 0.0054,-0.01758 0.0081,-0.05102 0.0081,-0.100341 l 0,-0.04102"
+         inkscape:connector-curvature="0"
+         id="path4118"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 23.30127,82.611122 0,0.164063 -0.140625,0 0,0.313476 c -10e-7,0.06348 0.0012,0.100586 0.0037,0.111328 0.0029,0.01025 0.009,0.0188 0.01831,0.02563 0.0098,0.0068 0.02148,0.01025 0.03516,0.01025 0.01904,0 0.04663,-0.0066 0.08276,-0.01977 l 0.01758,0.159668 c -0.04785,0.02051 -0.102051,0.03076 -0.162597,0.03076 -0.03711,0 -0.07056,-0.0061 -0.100342,-0.01831 -0.02979,-0.0127 -0.05176,-0.02881 -0.06592,-0.04834 -0.01367,-0.02002 -0.02319,-0.04687 -0.02857,-0.08057 -0.0044,-0.02393 -0.0066,-0.07227 -0.0066,-0.145019 l 0,-0.339111 -0.09448,0 0,-0.164063 0.09448,0 0,-0.154541 0.206543,-0.120117 0,0.274658 0.140625,0"
+         inkscape:connector-curvature="0"
+         id="path4120"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 23.397949,82.989052 c 0,-0.06836 0.01685,-0.134521 0.05054,-0.198487 0.03369,-0.06396 0.0813,-0.112792 0.142823,-0.146484 0.06201,-0.03369 0.131103,-0.05054 0.207275,-0.05054 0.117675,10e-7 0.214111,0.03833 0.289307,0.11499 0.07519,0.07617 0.112792,0.172608 0.112793,0.289307 -10e-7,0.117676 -0.03809,0.215332 -0.114258,0.292969 -0.07568,0.07715 -0.171143,0.115722 -0.286377,0.115722 -0.07129,0 -0.139405,-0.01611 -0.204346,-0.04834 -0.06445,-0.03223 -0.113525,-0.07935 -0.147217,-0.141357 -0.03369,-0.0625 -0.05054,-0.138427 -0.05054,-0.227783 m 0.210938,0.01099 c -1e-6,0.07715 0.01831,0.136231 0.05493,0.177246 0.03662,0.04102 0.08179,0.06152 0.135498,0.06152 0.05371,0 0.09863,-0.02051 0.134766,-0.06152 0.03662,-0.04102 0.05493,-0.100585 0.05493,-0.178711 -1e-6,-0.07617 -0.01831,-0.134765 -0.05493,-0.175781 -0.03613,-0.04102 -0.08105,-0.06152 -0.134766,-0.06152 -0.05371,0 -0.09888,0.02051 -0.135498,0.06152 -0.03662,0.04102 -0.05493,0.100098 -0.05493,0.177246"
+         inkscape:connector-curvature="0"
+         id="path4122"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 24.55957,83.388954 -0.20581,0 0,-0.777832 0.191162,0 0,0.110596 c 0.03271,-0.05225 0.06201,-0.08667 0.08789,-0.103272 0.02637,-0.0166 0.05615,-0.0249 0.08936,-0.0249 0.04687,10e-7 0.09204,0.01294 0.135498,0.03882 l -0.06372,0.179444 c -0.03467,-0.02246 -0.0669,-0.03369 -0.09668,-0.03369 -0.02881,10e-7 -0.05322,0.0081 -0.07324,0.02417 -0.02002,0.01563 -0.03589,0.04419 -0.04761,0.08569 -0.01123,0.0415 -0.01685,0.128418 -0.01685,0.260742 l 0,0.240234"
+         inkscape:connector-curvature="0"
+         id="path4124"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 24.873047,83.16703 0.206543,-0.03149 c 0.0088,0.04004 0.02661,0.07056 0.05347,0.09155 0.02685,0.02051 0.06445,0.03076 0.112793,0.03076 0.05322,0 0.09326,-0.0098 0.120117,-0.0293 0.01807,-0.01367 0.0271,-0.03198 0.0271,-0.05493 0,-0.01563 -0.0049,-0.02856 -0.01465,-0.03882 -0.01025,-0.0098 -0.0332,-0.0188 -0.06885,-0.0271 -0.166016,-0.03662 -0.27124,-0.07007 -0.315674,-0.100342 -0.06152,-0.04199 -0.09229,-0.100341 -0.09229,-0.175048 0,-0.06738 0.02661,-0.124023 0.07983,-0.169922 0.05322,-0.0459 0.135742,-0.06885 0.247559,-0.06885 0.106445,1e-6 0.185546,0.01734 0.237305,0.052 0.05176,0.03467 0.0874,0.08594 0.106933,0.153809 l -0.194092,0.03589 c -0.0083,-0.03027 -0.02417,-0.05347 -0.04761,-0.06958 -0.02295,-0.01611 -0.05591,-0.02417 -0.09888,-0.02417 -0.0542,10e-7 -0.09302,0.0076 -0.116455,0.0227 -0.01563,0.01074 -0.02344,0.02466 -0.02344,0.04175 0,0.01465 0.0068,0.0271 0.02051,0.03735 0.01855,0.01367 0.08252,0.03296 0.191895,0.05786 0.109862,0.0249 0.186523,0.05542 0.22998,0.09155 0.04297,0.03662 0.06445,0.08765 0.06445,0.153076 0,0.07129 -0.02979,0.132569 -0.08936,0.183838 -0.05957,0.05127 -0.147706,0.0769 -0.264404,0.0769 -0.105958,0 -0.189942,-0.02148 -0.251954,-0.06445 -0.06152,-0.04297 -0.101806,-0.101318 -0.120849,-0.175049"
+         inkscape:connector-curvature="0"
+         id="path4126"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 26.148926,82.989052 c 0,-0.06836 0.01685,-0.134521 0.05054,-0.198487 0.03369,-0.06396 0.0813,-0.112792 0.142822,-0.146484 0.06201,-0.03369 0.131103,-0.05054 0.207276,-0.05054 0.117675,10e-7 0.21411,0.03833 0.289306,0.11499 0.0752,0.07617 0.112792,0.172608 0.112793,0.289307 -1e-6,0.117676 -0.03809,0.215332 -0.114258,0.292969 -0.07568,0.07715 -0.171143,0.115722 -0.286377,0.115722 -0.07129,0 -0.139404,-0.01611 -0.204345,-0.04834 -0.06445,-0.03223 -0.113526,-0.07935 -0.147217,-0.141357 -0.03369,-0.0625 -0.05054,-0.138427 -0.05054,-0.227783 m 0.210937,0.01099 c 0,0.07715 0.01831,0.136231 0.05493,0.177246 0.03662,0.04102 0.08179,0.06152 0.135498,0.06152 0.05371,0 0.09863,-0.02051 0.134766,-0.06152 0.03662,-0.04102 0.05493,-0.100585 0.05493,-0.178711 0,-0.07617 -0.01831,-0.134765 -0.05493,-0.175781 -0.03613,-0.04102 -0.08106,-0.06152 -0.134766,-0.06152 -0.05371,0 -0.09888,0.02051 -0.135498,0.06152 -0.03662,0.04102 -0.05493,0.100098 -0.05493,0.177246"
+         inkscape:connector-curvature="0"
+         id="path4128"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 27.821045,83.388954 -0.205811,0 0,-0.396972 c 0,-0.08398 -0.0044,-0.138184 -0.01318,-0.162598 -0.0088,-0.0249 -0.02319,-0.04419 -0.04321,-0.05786 -0.01953,-0.01367 -0.04321,-0.02051 -0.07105,-0.02051 -0.03564,0 -0.06763,0.0098 -0.09595,0.0293 -0.02832,0.01953 -0.04785,0.04541 -0.05859,0.07764 -0.01025,0.03223 -0.01538,0.0918 -0.01538,0.178711 l 0,0.352295 -0.20581,0 0,-0.777832 0.191162,0 0,0.114258 c 0.06787,-0.08789 0.15332,-0.131835 0.256347,-0.131836 0.04541,1e-6 0.08691,0.0083 0.124512,0.0249 0.0376,0.01611 0.06592,0.03687 0.08496,0.06226 0.01953,0.02539 0.03296,0.0542 0.04028,0.08643 0.0078,0.03223 0.01172,0.07837 0.01172,0.138428 l 0,0.483398"
+         inkscape:connector-curvature="0"
+         id="path4130"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 28.030518,83.388954 0,-1.07373 0.20581,0 0,1.07373 -0.20581,0"
+         inkscape:connector-curvature="0"
+         id="path4132"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+      <path
+         d="m 28.349121,82.611122 0.218994,0 0.186035,0.552246 0.181641,-0.552246 0.213135,0 -0.274658,0.748535 -0.04907,0.135498 c -0.01807,0.04541 -0.0354,0.08008 -0.052,0.104004 -0.01611,0.02393 -0.03491,0.04321 -0.0564,0.05786 -0.021,0.01514 -0.04712,0.02685 -0.07837,0.03516 -0.03076,0.0083 -0.06567,0.01245 -0.104737,0.01245 -0.03955,0 -0.07837,-0.0042 -0.116455,-0.01245 l -0.01831,-0.161133 c 0.03223,0.0063 0.06128,0.0095 0.08716,0.0095 0.04785,0 0.08325,-0.01416 0.106201,-0.04248 0.02295,-0.02783 0.04053,-0.06348 0.05273,-0.106934 l -0.295899,-0.780029"
+         inkscape:connector-curvature="0"
+         id="path4134"
+         style="font-weight:bold;fill:#553417;-inkscape-font-specification:Abandoned Bitplane Bold" />
+    </g>
+    <g
+       id="text3762"
+       style="font-size:1.5px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#553417;fill-opacity:1;stroke:none;display:inline;font-family:Arial Black;-inkscape-font-specification:'Arial Black, Bold'">
+      <path
+         d="m 15.052002,78.15873 0.315674,-0.01978 c 0.0068,0.05127 0.02075,0.09033 0.04175,0.117188 0.03418,0.04346 0.08301,0.06518 0.146484,0.06518 0.04736,0 0.08374,-0.01099 0.109131,-0.03296 0.02588,-0.02246 0.03882,-0.04834 0.03882,-0.07764 0,-0.02783 -0.01221,-0.05273 -0.03662,-0.07471 -0.02441,-0.02197 -0.08106,-0.04272 -0.169922,-0.06226 -0.145508,-0.03271 -0.249267,-0.07617 -0.311279,-0.130371 -0.0625,-0.0542 -0.09375,-0.123291 -0.09375,-0.207276 0,-0.05517 0.01587,-0.107177 0.04761,-0.156006 0.03223,-0.04932 0.08032,-0.08789 0.144287,-0.115722 0.06445,-0.02832 0.152587,-0.04248 0.264404,-0.04248 0.137206,10e-7 0.241698,0.02564 0.313477,0.0769 0.07226,0.05078 0.115233,0.131837 0.128906,0.243165 l -0.312744,0.01831 c -0.0083,-0.04834 -0.02588,-0.0835 -0.05273,-0.105469 -0.02637,-0.02197 -0.06299,-0.03296 -0.109863,-0.03296 -0.03857,1e-6 -0.06763,0.0083 -0.08716,0.0249 -0.01953,0.01611 -0.0293,0.03589 -0.0293,0.05933 0,0.01709 0.0081,0.03247 0.02417,0.04614 0.01562,0.01416 0.05273,0.02734 0.111328,0.03955 0.145019,0.03125 0.248778,0.06299 0.311279,0.09521 0.06299,0.03174 0.108642,0.07129 0.136963,0.118652 0.02881,0.04736 0.04321,0.100343 0.04321,0.158936 -10e-7,0.06885 -0.01904,0.132324 -0.05713,0.19043 -0.03809,0.0581 -0.09131,0.102295 -0.159668,0.132568 -0.06836,0.02978 -0.154541,0.04468 -0.258545,0.04468 -0.182617,0 -0.309082,-0.03516 -0.379394,-0.105469 -0.07031,-0.07031 -0.110108,-0.159668 -0.119385,-0.268066"
+         inkscape:connector-curvature="0"
+         id="path4137" />
+      <path
+         d="m 16.137451,78.127235 c 0,-0.118651 0.04004,-0.216308 0.120117,-0.292968 0.08008,-0.07715 0.188232,-0.115722 0.324463,-0.115723 0.155761,1e-6 0.273437,0.04517 0.353028,0.135498 0.06396,0.07275 0.09595,0.162354 0.09595,0.268799 -1e-6,0.119629 -0.0398,0.217773 -0.119385,0.294433 -0.0791,0.07617 -0.188721,0.114258 -0.328857,0.114258 -0.125001,0 -0.226075,-0.03174 -0.303223,-0.09521 -0.09473,-0.07861 -0.14209,-0.18164 -0.14209,-0.309082 m 0.298828,-7.32e-4 c 0,0.06934 0.01392,0.120606 0.04175,0.153809 0.02832,0.0332 0.06372,0.0498 0.106202,0.0498 0.04297,0 0.07812,-0.01636 0.105468,-0.04907 0.02783,-0.03271 0.04175,-0.0852 0.04175,-0.157471 0,-0.06738 -0.01392,-0.117431 -0.04175,-0.150146 -0.02783,-0.0332 -0.06226,-0.0498 -0.103271,-0.04981 -0.04346,10e-7 -0.07935,0.01685 -0.107666,0.05054 -0.02832,0.0332 -0.04248,0.08398 -0.04248,0.152344"
+         inkscape:connector-curvature="0"
+         id="path4139" />
+      <path
+         d="m 17.507812,77.736122 0.14209,0 0,0.218262 -0.14209,0 0,0.55957 -0.298828,0 0,-0.55957 -0.111328,0 0,-0.218262 0.111328,0 0,-0.03516 c 0,-0.03174 0.0034,-0.06665 0.01025,-0.104736 0.0068,-0.03809 0.01953,-0.06909 0.03809,-0.09302 0.01904,-0.02441 0.04541,-0.04394 0.0791,-0.05859 0.03418,-0.01514 0.08398,-0.0227 0.149414,-0.02271 0.05224,10e-7 0.128173,0.0061 0.227783,0.01831 l -0.03296,0.180175 c -0.03564,-0.0059 -0.06445,-0.0088 -0.08643,-0.0088 -0.02686,10e-7 -0.04614,0.0046 -0.05786,0.01392 -0.01172,0.0088 -0.02002,0.02295 -0.0249,0.04248 -0.0024,0.01074 -0.0037,0.03345 -0.0037,0.06811"
+         inkscape:connector-curvature="0"
+         id="path4141" />
+      <path
+         d="m 18.118652,77.440224 0,0.295898 0.164063,0 0,0.217529 -0.164063,0 0,0.276123 c 0,0.0332 0.0032,0.05518 0.0095,0.06592 0.0098,0.0166 0.02685,0.0249 0.05127,0.0249 0.02197,0 0.05273,-0.0063 0.09229,-0.01904 l 0.02197,0.20581 c -0.07373,0.01611 -0.142578,0.02417 -0.206543,0.02417 -0.07422,0 -0.128906,-0.0095 -0.164062,-0.02856 -0.03516,-0.01904 -0.06128,-0.04785 -0.07837,-0.08643 -0.0166,-0.03906 -0.0249,-0.102051 -0.0249,-0.188965 l 0,-0.273926 -0.109863,0 0,-0.217529 0.109863,0 0,-0.142822 0.298828,-0.153076"
+         inkscape:connector-curvature="0"
+         id="path4143" />
+      <path
+         d="m 18.336182,77.736122 0.288574,0 0.125244,0.48999 0.158203,-0.48999 0.268799,0 0.164062,0.48999 0.125245,-0.48999 0.286377,0 -0.286377,0.777832 -0.265137,0 -0.157471,-0.468017 -0.152344,0.468017 -0.266601,0 -0.288574,-0.777832"
+         inkscape:connector-curvature="0"
+         id="path4145" />
+      <path
+         d="m 20.093262,77.988075 -0.284912,-0.03003 c 0.01074,-0.0498 0.02612,-0.08887 0.04614,-0.117188 0.02051,-0.02881 0.0498,-0.05371 0.08789,-0.07471 0.02734,-0.01514 0.06494,-0.02685 0.112793,-0.03516 0.04785,-0.0083 0.09961,-0.01245 0.155273,-0.01245 0.08936,10e-7 0.161132,0.0051 0.215332,0.01538 0.0542,0.0098 0.09936,0.03052 0.135498,0.06226 0.02539,0.02197 0.04541,0.05322 0.06006,0.09375 0.01465,0.04004 0.02197,0.07837 0.02197,0.11499 l 0,0.343506 c -10e-7,0.03662 0.0022,0.06543 0.0066,0.08643 0.0049,0.02051 0.01514,0.04687 0.03076,0.0791 l -0.279785,0 c -0.01123,-0.02002 -0.01855,-0.03516 -0.02197,-0.04541 -0.0034,-0.01074 -0.0068,-0.02734 -0.01025,-0.0498 -0.03906,0.0376 -0.07788,0.06445 -0.116455,0.08057 -0.05273,0.02148 -0.114014,0.03223 -0.183838,0.03223 -0.09277,0 -0.16333,-0.02148 -0.21167,-0.06445 -0.04785,-0.04297 -0.07178,-0.09595 -0.07178,-0.158935 0,-0.05908 0.01733,-0.107666 0.052,-0.145752 0.03467,-0.03809 0.09863,-0.06641 0.191895,-0.08496 0.111816,-0.02246 0.184325,-0.03809 0.217529,-0.04687 0.0332,-0.0093 0.06836,-0.02124 0.105469,-0.03589 -1e-6,-0.03662 -0.0076,-0.06226 -0.02271,-0.0769 -0.01514,-0.01465 -0.04175,-0.02197 -0.07983,-0.02197 -0.04883,10e-7 -0.08545,0.0078 -0.109864,0.02344 -0.01904,0.01221 -0.03442,0.03516 -0.04614,0.06885 m 0.258545,0.156739 c -0.04102,0.01465 -0.08374,0.02759 -0.128174,0.03882 -0.06055,0.01611 -0.09888,0.03198 -0.11499,0.04761 -0.0166,0.01611 -0.0249,0.03442 -0.0249,0.05493 0,0.02344 0.0081,0.04273 0.02417,0.05786 0.0166,0.01465 0.04077,0.02197 0.07251,0.02197 0.0332,0 0.06396,-0.0081 0.09228,-0.02417 0.02881,-0.01611 0.04907,-0.03564 0.06079,-0.05859 0.01221,-0.02344 0.01831,-0.05371 0.01831,-0.09082 l 0,-0.04761"
+         inkscape:connector-curvature="0"
+         id="path4147" />
+      <path
+         d="m 20.826416,77.736122 0.279053,0 0,0.127442 c 0.02686,-0.05518 0.05444,-0.09302 0.08276,-0.113526 0.02881,-0.02099 0.06421,-0.03149 0.106202,-0.03149 0.04394,10e-7 0.09204,0.01367 0.144287,0.04102 l -0.09229,0.212402 c -0.03516,-0.01465 -0.06299,-0.02197 -0.0835,-0.02197 -0.03906,10e-7 -0.06934,0.01611 -0.09082,0.04834 -0.03076,0.04541 -0.04614,0.130372 -0.04614,0.254883 l 0,0.260742 -0.299561,0 0,-0.777832"
+         inkscape:connector-curvature="0"
+         id="path4149" />
+      <path
+         d="m 22.375488,78.199013 -0.597656,0 c 0.0054,0.04785 0.01831,0.0835 0.03882,0.106933 0.02881,0.03369 0.06641,0.05054 0.112793,0.05054 0.0293,10e-7 0.05713,-0.0073 0.0835,-0.02197 0.01611,-0.0093 0.03345,-0.02564 0.052,-0.04907 l 0.293702,0.0271 c -0.04492,0.07813 -0.09912,0.134278 -0.162598,0.168457 -0.06348,0.03369 -0.154542,0.05054 -0.273193,0.05054 -0.103028,0 -0.184083,-0.0144 -0.243165,-0.04321 -0.05908,-0.0293 -0.108154,-0.07544 -0.147216,-0.138427 -0.03858,-0.06348 -0.05786,-0.137939 -0.05786,-0.223389 0,-0.121582 0.03882,-0.21997 0.116455,-0.295166 0.07813,-0.0752 0.185791,-0.112792 0.322998,-0.112793 0.111328,10e-7 0.199219,0.01685 0.263672,0.05054 0.06445,0.03369 0.113525,0.08252 0.147217,0.146484 0.03369,0.06397 0.05054,0.147218 0.05054,0.249756 l 0,0.03369 M 22.072266,78.05619 c -0.0059,-0.05762 -0.02148,-0.09888 -0.04687,-0.123779 -0.0249,-0.0249 -0.05786,-0.03735 -0.09888,-0.03735 -0.04736,0 -0.08521,0.0188 -0.113526,0.0564 -0.01807,0.02344 -0.02954,0.05835 -0.03442,0.104736 l 0.293702,0"
+         inkscape:connector-curvature="0"
+         id="path4151" />
+      <path
+         d="m 23.01709,77.736122 0.27832,0 0,0.113526 c 0.04004,-0.04736 0.08032,-0.08105 0.12085,-0.101075 0.04101,-0.02002 0.09033,-0.03003 0.147949,-0.03003 0.06201,10e-7 0.111083,0.01099 0.147217,0.03296 0.03613,0.02197 0.06567,0.05469 0.08862,0.09815 0.04687,-0.05078 0.0896,-0.08521 0.128174,-0.103272 0.03857,-0.01855 0.08618,-0.02783 0.142822,-0.02783 0.08349,10e-7 0.14868,0.0249 0.195557,0.07471 0.04687,0.04932 0.07031,0.12671 0.07031,0.232178 l 0,0.488525 -0.298828,0 0,-0.443115 c -10e-7,-0.03516 -0.0068,-0.06128 -0.02051,-0.07837 -0.02002,-0.02685 -0.04492,-0.04028 -0.07471,-0.04028 -0.03516,0 -0.06348,0.0127 -0.08496,0.03809 -0.02149,0.02539 -0.03223,0.06616 -0.03223,0.122314 l 0,0.401367 -0.298829,0 0,-0.428467 c 0,-0.03418 -0.002,-0.05737 -0.0059,-0.06958 -0.0063,-0.01953 -0.01733,-0.03516 -0.03296,-0.04687 -0.01563,-0.01221 -0.03394,-0.01831 -0.05493,-0.01831 -0.03418,0 -0.06226,0.01294 -0.08423,0.03882 -0.02197,0.02588 -0.03296,0.06836 -0.03296,0.127442 l 0,0.396972 -0.298828,0 0,-0.777832"
+         inkscape:connector-curvature="0"
+         id="path4153" />
+      <path
+         d="m 24.786621,77.988075 -0.284912,-0.03003 c 0.01074,-0.0498 0.02612,-0.08887 0.04614,-0.117188 0.02051,-0.02881 0.0498,-0.05371 0.08789,-0.07471 0.02734,-0.01514 0.06494,-0.02685 0.112793,-0.03516 0.04785,-0.0083 0.09961,-0.01245 0.155274,-0.01245 0.08935,10e-7 0.161132,0.0051 0.215332,0.01538 0.0542,0.0098 0.09936,0.03052 0.135498,0.06226 0.02539,0.02197 0.04541,0.05322 0.06006,0.09375 0.01465,0.04004 0.02197,0.07837 0.02197,0.11499 l 0,0.343506 c -1e-6,0.03662 0.0022,0.06543 0.0066,0.08643 0.0049,0.02051 0.01514,0.04687 0.03076,0.0791 l -0.279785,0 c -0.01123,-0.02002 -0.01855,-0.03516 -0.02197,-0.04541 -0.0034,-0.01074 -0.0068,-0.02734 -0.01025,-0.0498 -0.03906,0.0376 -0.07788,0.06445 -0.116455,0.08057 -0.05274,0.02148 -0.114014,0.03223 -0.183838,0.03223 -0.09277,0 -0.163331,-0.02148 -0.21167,-0.06445 -0.04785,-0.04297 -0.07178,-0.09595 -0.07178,-0.158935 0,-0.05908 0.01733,-0.107666 0.052,-0.145752 0.03467,-0.03809 0.09863,-0.06641 0.191895,-0.08496 0.111816,-0.02246 0.184326,-0.03809 0.217529,-0.04687 0.0332,-0.0093 0.06836,-0.02124 0.105469,-0.03589 -1e-6,-0.03662 -0.0076,-0.06226 -0.0227,-0.0769 -0.01514,-0.01465 -0.04175,-0.02197 -0.07983,-0.02197 -0.04883,10e-7 -0.08545,0.0078 -0.109863,0.02344 -0.01904,0.01221 -0.03443,0.03516 -0.04614,0.06885 m 0.258545,0.156739 c -0.04102,0.01465 -0.08374,0.02759 -0.128174,0.03882 -0.06055,0.01611 -0.09888,0.03198 -0.11499,0.04761 -0.0166,0.01611 -0.0249,0.03442 -0.0249,0.05493 -10e-7,0.02344 0.0081,0.04273 0.02417,0.05786 0.0166,0.01465 0.04077,0.02197 0.07251,0.02197 0.0332,0 0.06396,-0.0081 0.09229,-0.02417 0.02881,-0.01611 0.04907,-0.03564 0.06079,-0.05859 0.01221,-0.02344 0.01831,-0.05371 0.01831,-0.09082 l 0,-0.04761"
+         inkscape:connector-curvature="0"
+         id="path4155" />
+      <path
+         d="m 25.516846,77.736122 0.277588,0 0,0.126709 c 0.0415,-0.05176 0.0835,-0.08862 0.125976,-0.110596 0.04248,-0.02246 0.09424,-0.03369 0.155274,-0.03369 0.08252,10e-7 0.146971,0.02466 0.193359,0.07398 0.04687,0.04883 0.07031,0.124512 0.07031,0.22705 l 0,0.494385 -0.29956,0 0,-0.427734 c -1e-6,-0.04883 -0.009,-0.08325 -0.0271,-0.103272 -0.01807,-0.02051 -0.04346,-0.03076 -0.07617,-0.03076 -0.03613,0 -0.06543,0.01367 -0.08789,0.04102 -0.02246,0.02734 -0.03369,0.07642 -0.03369,0.147217 l 0,0.373535 -0.298095,0 0,-0.777832"
+         inkscape:connector-curvature="0"
+         id="path4157" />
+      <path
+         d="m 26.790527,77.988075 -0.284912,-0.03003 c 0.01074,-0.0498 0.02612,-0.08887 0.04614,-0.117188 0.02051,-0.02881 0.0498,-0.05371 0.08789,-0.07471 0.02734,-0.01514 0.06494,-0.02685 0.112793,-0.03516 0.04785,-0.0083 0.09961,-0.01245 0.155274,-0.01245 0.08936,10e-7 0.161132,0.0051 0.215332,0.01538 0.0542,0.0098 0.09936,0.03052 0.135498,0.06226 0.02539,0.02197 0.04541,0.05322 0.06006,0.09375 0.01465,0.04004 0.02197,0.07837 0.02197,0.11499 l 0,0.343506 c -1e-6,0.03662 0.0022,0.06543 0.0066,0.08643 0.0049,0.02051 0.01514,0.04687 0.03076,0.0791 l -0.279785,0 c -0.01123,-0.02002 -0.01856,-0.03516 -0.02197,-0.04541 -0.0034,-0.01074 -0.0068,-0.02734 -0.01025,-0.0498 -0.03906,0.0376 -0.07788,0.06445 -0.116455,0.08057 -0.05274,0.02148 -0.114014,0.03223 -0.183838,0.03223 -0.09277,0 -0.16333,-0.02148 -0.21167,-0.06445 -0.04785,-0.04297 -0.07178,-0.09595 -0.07178,-0.158935 0,-0.05908 0.01733,-0.107666 0.052,-0.145752 0.03467,-0.03809 0.09863,-0.06641 0.191894,-0.08496 0.111816,-0.02246 0.184326,-0.03809 0.21753,-0.04687 0.0332,-0.0093 0.06836,-0.02124 0.105468,-0.03589 0,-0.03662 -0.0076,-0.06226 -0.0227,-0.0769 -0.01514,-0.01465 -0.04175,-0.02197 -0.07983,-0.02197 -0.04883,10e-7 -0.08545,0.0078 -0.109863,0.02344 -0.01904,0.01221 -0.03442,0.03516 -0.04614,0.06885 m 0.258545,0.156739 c -0.04102,0.01465 -0.08374,0.02759 -0.128174,0.03882 -0.06055,0.01611 -0.09888,0.03198 -0.11499,0.04761 -0.0166,0.01611 -0.0249,0.03442 -0.0249,0.05493 0,0.02344 0.0081,0.04273 0.02417,0.05786 0.0166,0.01465 0.04077,0.02197 0.07251,0.02197 0.0332,0 0.06396,-0.0081 0.09229,-0.02417 0.02881,-0.01611 0.04907,-0.03564 0.06079,-0.05859 0.01221,-0.02344 0.01831,-0.05371 0.01831,-0.09082 l 0,-0.04761"
+         inkscape:connector-curvature="0"
+         id="path4159" />
+      <path
+         d="m 28.085449,77.736122 0.279053,0 0,0.734619 7.32e-4,0.03442 c -1e-6,0.04883 -0.0105,0.09521 -0.03149,0.13916 -0.02051,0.04443 -0.0481,0.08032 -0.08276,0.107666 -0.03418,0.02734 -0.07788,0.04712 -0.131104,0.05933 -0.05273,0.01221 -0.113282,0.01831 -0.181641,0.01831 -0.15625,0 -0.263672,-0.02344 -0.322265,-0.07031 -0.05811,-0.04687 -0.08716,-0.109619 -0.08716,-0.188232 0,-0.0098 4.88e-4,-0.02295 0.0015,-0.03955 l 0.289307,0.03296 c 0.0073,0.02686 0.01855,0.04541 0.03369,0.05566 0.02197,0.01514 0.04956,0.02271 0.08276,0.02271 0.04297,0 0.07495,-0.01147 0.09595,-0.03442 0.02148,-0.02295 0.03223,-0.06299 0.03223,-0.120118 l 0,-0.11792 c -0.0293,0.03467 -0.05859,0.05982 -0.08789,0.07544 -0.0459,0.02441 -0.09546,0.03662 -0.148681,0.03662 -0.104004,0 -0.187989,-0.04541 -0.251953,-0.13623 -0.04541,-0.06445 -0.06812,-0.149658 -0.06812,-0.255616 0,-0.121093 0.0293,-0.213378 0.08789,-0.276855 0.05859,-0.06348 0.135254,-0.09521 0.22998,-0.09522 0.06055,10e-7 0.110352,0.01026 0.149415,0.03076 0.03955,0.02051 0.07642,0.05444 0.110595,0.101806 l 0,-0.11499 m -0.280517,0.377197 c -1e-6,0.05615 0.01196,0.0979 0.03589,0.125245 0.02393,0.02685 0.05542,0.04028 0.09448,0.04028 0.03711,0 0.06811,-0.01392 0.09302,-0.04175 0.02539,-0.02832 0.03809,-0.0708 0.03809,-0.127442 0,-0.05664 -0.01318,-0.09985 -0.03955,-0.129638 -0.02637,-0.03027 -0.05859,-0.04541 -0.09668,-0.04541 -0.03809,1e-6 -0.0686,0.01392 -0.09155,0.04175 -0.02246,0.02734 -0.03369,0.073 -0.03369,0.136962"
+         inkscape:connector-curvature="0"
+         id="path4161" />
+      <path
+         d="m 29.409668,78.199013 -0.597656,0 c 0.0054,0.04785 0.01831,0.0835 0.03882,0.106933 0.02881,0.03369 0.06641,0.05054 0.112793,0.05054 0.0293,10e-7 0.05713,-0.0073 0.0835,-0.02197 0.01611,-0.0093 0.03345,-0.02564 0.052,-0.04907 l 0.293701,0.0271 c -0.04492,0.07813 -0.09912,0.134278 -0.162597,0.168457 -0.06348,0.03369 -0.154542,0.05054 -0.273194,0.05054 -0.103027,0 -0.184082,-0.0144 -0.243164,-0.04321 -0.05908,-0.0293 -0.108154,-0.07544 -0.147217,-0.138427 -0.03857,-0.06348 -0.05786,-0.137939 -0.05786,-0.223389 0,-0.121582 0.03882,-0.21997 0.116455,-0.295166 0.07813,-0.0752 0.185791,-0.112792 0.322998,-0.112793 0.111328,10e-7 0.199218,0.01685 0.263672,0.05054 0.06445,0.03369 0.113525,0.08252 0.147217,0.146484 0.03369,0.06397 0.05054,0.147218 0.05054,0.249756 l 0,0.03369 M 29.106445,78.05619 c -0.0059,-0.05762 -0.02149,-0.09888 -0.04687,-0.123779 -0.0249,-0.0249 -0.05786,-0.03735 -0.09888,-0.03735 -0.04736,0 -0.0852,0.0188 -0.113525,0.0564 -0.01807,0.02344 -0.02954,0.05835 -0.03442,0.104736 l 0.293701,0"
+         inkscape:connector-curvature="0"
+         id="path4163" />
+      <path
+         d="m 29.551025,77.736122 0.279053,0 0,0.127442 c 0.02686,-0.05518 0.05444,-0.09302 0.08276,-0.113526 0.02881,-0.02099 0.06421,-0.03149 0.106201,-0.03149 0.04395,10e-7 0.09204,0.01367 0.144287,0.04102 l -0.09228,0.212402 c -0.03516,-0.01465 -0.06299,-0.02197 -0.0835,-0.02197 -0.03906,10e-7 -0.06934,0.01611 -0.09082,0.04834 -0.03076,0.04541 -0.04614,0.130372 -0.04614,0.254883 l 0,0.260742 -0.299561,0 0,-0.777832"
+         inkscape:connector-curvature="0"
+         id="path4165" />
+    </g>
+  </g>
+  <g
+     id="layer4"
+     style="display:none">
+    <rect
+       width="30"
+       height="30"
+       rx="2.8125"
+       ry="2.8125"
+       x="-86"
+       y="56"
+       transform="matrix(0,-1,1,0,0,4)"
+       id="rect3790"
+       style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;filter:url(#filter3806)" />
+    <rect
+       width="30"
+       height="30"
+       rx="2.8125"
+       ry="2.8125"
+       x="-88"
+       y="56"
+       transform="matrix(0,-1,1,0,0,0)"
+       id="rect2993"
+       style="fill:url(#linearGradient3773);fill-opacity:1;stroke:none" />
+    <path
+       d="M 58.8125,58 C 57.254375,58 56,59.254375 56,60.8125 l 0,24.375 c 0,0.873066 0.410816,1.641163 1.03125,2.15625 C 57.02841,87.289908 57,87.242129 57,87.1875 l 0,-24.375 C 57,61.254375 58.17075,60 59.625,60 l 22.75,0 C 83.82925,60 85,61.254375 85,62.8125 l 0,24.375 c 0,0.05463 -0.02841,0.102408 -0.03125,0.15625 C 85.589184,86.828663 86,86.060566 86,85.1875 l 0,-24.375 C 86,59.254375 84.745625,58 83.1875,58 l -24.375,0 z"
+       inkscape:connector-curvature="0"
+       id="rect3775"
+       style="opacity:0.5;fill:url(#linearGradient3788);fill-opacity:1;stroke:none" />
+    <path
+       d="m 116,63.5 0,8.75 -5,0 10,13.75 10,-13.75 -5,0 0,-8.75 -10,0 z"
+       inkscape:connector-curvature="0"
+       transform="translate(-50,0)"
+       clip-path="url(#clipPath3823)"
+       id="path3810"
+       style="opacity:0.6;fill:url(#linearGradient3812);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;filter:url(#filter3831)" />
+    <path
+       d="m 66,62.5 0,8.75 -5,0 10,13.75 10,-13.75 -5,0 0,-8.75 -10,0 z"
+       inkscape:connector-curvature="0"
+       id="path4278"
+       style="fill:url(#linearGradient3832);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+  </g>
+  <g
+     id="layer6"
+     style="display:none">
+    <rect
+       width="36"
+       height="36"
+       rx="18"
+       ry="18"
+       x="50"
+       y="118"
+       transform="translate(1.373291e-7,-60)"
+       clip-path="url(#clipPath3871)"
+       id="rect3859"
+       style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;display:inline;filter:url(#filter3866)" />
+    <path
+       d="m 90.714283,72.785713 a 19.642857,19.642857 0 1 1 -39.285713,0 19.642857,19.642857 0 1 1 39.285713,0 z"
+       transform="matrix(0,-0.91636366,0.91636366,0,1.3018175,139.12727)"
+       id="path3836"
+       style="fill:url(#linearGradient3844);fill-opacity:1;stroke:none" />
+    <path
+       d="m 67.985086,56.378807 -2.057995,0.23861 -2.535211,0.70091 -0.477216,0.4623 1.580779,1.08865 0,0.62635 -0.626347,0.62635 0.820215,1.62551 0.551782,-0.29826 0.685998,-1.10356 c 1.060186,-0.3284 2.019644,-0.69624 3.027341,-1.16321 l 0.820215,-2.10274 -1.789561,-0.70091 z m -4.816901,0.25352 c -0.453342,0.12819 -0.903975,0.27064 -1.342171,0.43248 l -0.01491,0.0149 c -0.0087,0.003 -0.02114,-0.003 -0.02983,0 -0.604892,0.22522 -1.187288,0.48949 -1.759734,0.77548 l 0.89478,0.16404 0.342999,-0.31317 0.685998,-0.14913 c 0.470145,-0.22909 0.947717,-0.39014 1.446562,-0.55178 l -0.223695,-0.37283 z m -4.101077,1.77465 -0.134217,0.31317 0.05965,0.77548 -0.536868,0.4623 -0.342999,0.86496 0.685998,0 0.342999,-0.77548 c 0.295964,-0.2097 0.578427,-0.4245 0.879868,-0.62635 l 0.685998,0.23861 c 0.457306,0.31128 0.914313,0.6138 1.371996,0.92461 l 0.700912,-0.62635 -0.760563,-0.29826 -0.343,-0.70091 -1.312344,-0.16404 -0.05965,-0.38774 -0.626346,0.14913 -0.268434,0.55178 -0.343,-0.70091 z m 17.582435,0.62635 -1.312345,0.31317 -0.820215,0.53687 0,0.4623 -1.297432,0.86495 0.268435,1.23778 0.760563,-0.53686 0.477216,0.53686 0.551781,0.31318 0.342999,-0.92461 -0.208782,-0.55178 0.208782,-0.38774 0.745651,-0.70091 0.342999,0 -0.342999,0.77548 0,0.70091 c 0.315318,-0.086 0.646663,-0.10893 0.969345,-0.14913 l -0.89478,0.61143 -0.07457,0.40265 -1.028998,0.85004 -1.028997,-0.23861 0,-0.61143 -0.477217,0.29826 0.208783,0.55178 -0.760563,0 -0.402652,0.70091 -0.521955,0.58161 -0.924606,0.19387 0.551781,0.55178 0.134217,0.53687 -0.685998,0 -0.894781,0.47722 0,1.38691 0.417565,0 0.372825,0.43247 0.864954,-0.43247 0.342999,-0.85005 0.611433,-0.38773 0.134218,-0.31318 1.028997,-0.23861 0.551781,0.62635 0.611433,0.31317 -0.342999,0.70092 0.551782,-0.14913 0.283347,-0.70092 -0.685999,-0.79039 0.268434,0 0.685999,0.55179 0.134217,0.77547 0.626346,0.70091 0.134217,-1.01408 0.342999,-0.14913 c 0.339298,0.3529 0.609012,0.76604 0.89478,1.16321 l 1.028998,0.0746 0.611433,0.38774 -0.268434,0.38773 -0.626346,0.55179 -0.879867,0 -1.178128,-0.38774 -0.611433,0.0746 -0.447391,0.50704 -1.267605,-1.28251 -0.894781,-0.23861 -1.297431,0.16404 -1.178127,0.31317 c -0.654616,0.74355 -1.289274,1.47967 -1.908865,2.25187 l -0.760564,1.78956 0.343,0.38774 -0.611434,0.93952 0.685999,1.62551 c 0.583527,0.66135 1.162143,1.32161 1.744821,1.98343 l 0.850042,-0.73074 0.387738,0.43248 0.924606,-0.59652 0.313173,0.35791 0.924607,0 0.521955,0.59653 -0.328086,1.07373 0.656172,0.74565 -0.02983,1.28252 0.477216,0.92461 -0.342999,0.79038 c -0.03418,0.57263 -0.05965,1.12737 -0.05965,1.70009 0.281238,0.77589 0.55465,1.55987 0.820216,2.34134 l 0.193869,1.23778 0,0.62634 0.49213,0 0.74565,-0.4623 0.894781,0 1.34217,-1.52112 -0.178956,-0.50705 0.89478,-0.77547 -0.656172,-0.74566 0.790389,-0.65617 0.760564,-0.4623 0.342999,-0.38774 -0.208782,-0.86495 c 0,-0.72595 0,-1.45126 0,-2.1773 l 0.626346,-1.32726 0.74565,-0.85004 0.820216,-2.02817 0,-0.53686 c -0.406913,0.0513 -0.794985,0.0904 -1.193041,0.1193 l -0.02982,0.0298 -0.02982,-0.0298 c -0.240947,0.0164 -0.482983,0.0298 -0.730737,0.0298 -0.437008,-0.92004 -0.770779,-1.84113 -1.103563,-2.80364 l -0.581607,-0.65617 -0.29826,-1.13339 0.193869,-0.2237 0.79039,0.89478 0.924606,1.98343 0.551781,0.61144 -0.268434,0.70091 0.521955,0.59652 c 0.01963,-0.001 0.04004,0.001 0.05965,0 l 0.820216,-0.82022 1.133388,-0.77547 0.626345,-0.70091 0,-0.79039 c -0.137362,-0.25953 -0.279259,-0.51591 -0.417565,-0.77546 l -0.551781,0.62635 -0.417564,-0.46231 -0.611433,-0.47721 0,-0.99917 0.715824,0.8053 0.79039,-0.10439 c 0.3595,0.32698 0.713678,0.62688 1.028999,0.99917 l 0.507042,-0.5667 c -0.725536,-4.44474 -3.07624,-8.34317 -6.412595,-11.08036 l -0.134217,0.20879 -0.685998,0.77547 -0.879867,-0.9246 0.879867,0 0.372825,-0.41757 c -0.03078,-0.0237 -0.05854,-0.0511 -0.08948,-0.0746 l -1.506214,-0.28335 -0.89478,-0.31317 z m -18.760562,0.0597 c -0.242646,0.16567 -0.46691,0.34501 -0.700912,0.52195 l -0.104391,0.26844 c 0,0 -0.188073,0.0315 -0.328086,0.0596 -3.882634,3.12203 -6.456825,7.81685 -6.755592,13.10853 0.186423,0.32011 0.417564,0.686 0.417564,0.686 l 1.446562,0.85004 1.431648,0.40265 0.626347,0.77548 0.954432,0.70091 0.551782,-0.0895 0.417564,0.19387 0,0.1193 -0.551782,1.47639 -0.417564,0.62635 0.134217,0.31317 -0.342999,1.16321 1.23778,2.26678 1.237779,1.08865 0.551781,0.77548 -0.07456,1.64043 0.417565,0.9246 -0.417565,1.78956 c 0,0 -0.0098,0.0132 0.01491,0.11931 0.576819,0.40897 1.180569,0.79285 1.804474,1.13338 0.0098,0.005 0.02004,0.01 0.02982,0.0149 0.02683,0.0126 0.06416,0.0333 0.08948,0.0447 0.221179,0.1004 0.38346,0.15962 0.417564,0.13422 0.135945,-0.10348 0.253521,-0.19387 0.253521,-0.19387 l -0.134217,-0.38774 0.551782,-0.55178 0.208782,-0.53687 0.879867,-0.31317 0.685998,-1.715 -0.193869,-0.4623 0.477216,-0.70091 1.028998,-0.23861 0.551781,-1.25269 -0.134217,-1.55095 0.820216,-1.16322 0.134217,-1.16321 c -1.12665,-0.55976 -2.252094,-1.13869 -3.37034,-1.715 l -0.536868,-1.08865 -1.028998,-0.23861 -0.551781,-1.47638 -1.371996,0.14913 -1.163215,-0.85004 -1.23778,1.08864 0,0.16405 c -0.373849,-0.10811 -0.830336,-0.12302 -1.163214,-0.32809 l -0.283347,-0.77548 0,-0.85003 -0.820216,0.0746 c 0.06873,-0.545 0.139583,-1.08061 0.208783,-1.62552 l -0.49213,0 -0.477216,0.61144 -0.477216,0.2386 -0.685999,-0.38773 -0.07456,-0.86496 0.149129,-0.9246 1.028998,-0.77548 0.820215,0 0.134218,-0.47722 1.028997,0.23861 0.760563,0.93952 0.134217,-1.56586 1.297432,-1.08865 0.492129,-1.16322 0.954433,-0.38774 0.551781,-0.77547 1.237779,-0.23861 0.611434,-0.93952 c -0.617702,0 -1.231511,0 -1.849213,0 l 1.163214,-0.53687 0.820216,0 1.163214,-0.38774 0.14913,-0.47721 -0.417564,-0.38774 -0.477216,-0.14913 0.134217,-0.4623 -0.342999,-0.70091 -0.820216,0.29826 0.134217,-0.61144 -0.954432,-0.55178 -0.760563,1.32726 0.07456,0.4623 -0.760563,0.31317 -0.477217,1.01409 -0.208782,-0.93952 -1.297432,-0.53687 -0.208782,-0.70091 1.714996,-1.01408 0.74565,-0.70092 0.07456,-0.85004 -0.417564,-0.2386 -0.07456,-0.0149 z m 11.945318,0.95443 -0.536868,0.29826 -0.283348,-0.0746 -0.05965,0.47721 0.477217,0.29826 0.820215,-0.53687 -0.417564,-0.4623 z m -9.052195,0.14913 -0.551782,0.38774 0.685999,0.4623 0.551781,0 0,-0.53687 -0.685998,-0.31317 z m 10.841755,1.78956 0,0.4623 0.283348,0.31318 0,0.70091 -0.14913,0.93952 0.760563,-0.16405 0.551781,-0.53686 -0.477216,-0.46231 c -0.161341,-0.43051 -0.349846,-0.83987 -0.551781,-1.25274 l -0.417564,0 z m -0.268433,0.93952 -0.49213,0.14913 0.14913,0.85004 0.611433,-0.29826 -0.268433,-0.70091 z m -9.469759,1.40182 0.193868,1.08865 0.417565,-0.62634 -0.611433,-0.46231 z"
+       inkscape:connector-curvature="0"
+       id="path4144"
+       style="fill:url(#radialGradient3146);fill-opacity:1;fill-rule:nonzero;stroke-miterlimit:4;display:inline" />
+    <g
+       id="g4106"
+       style="display:inline">
+      <path
+         d="m 68,56 c -9.941125,0 -18,8.058875 -18,18 0,3.6617 1.09067,7.063961 2.96875,9.90625 C 51.722125,81.541769 51,78.858787 51,76 c 0,-9.388841 7.611159,-17 17,-17 9.388841,0 17,7.611159 17,17 0,2.858787 -0.722125,5.541769 -1.96875,7.90625 C 84.90933,81.063961 86,77.6617 86,74 86,64.058875 77.941125,56 68,56 z"
+         inkscape:connector-curvature="0"
+         id="path3846"
+         style="opacity:0.3;fill:url(#linearGradient3857-6);fill-opacity:1;stroke:none" />
+      <path
+         d="m 68,56 c -9.94112,0 -18,8.05887 -18,18 0,0.168593 0.02664,0.33252 0.03125,0.5 C 50.298212,64.79197 58.227473,57 68,57 c 9.73052,0 17.63723,7.725255 17.96875,17.375 l 0,-1 C 85.63723,63.725255 77.73052,56 68,56 z"
+         inkscape:connector-curvature="0"
+         id="path4097"
+         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;display:inline" />
+    </g>
+  </g>
+  <g
+     id="layer7"
+     style="display:inline">
+    <path
+       d="m 68,116 c -11.060103,0 -20,8.93989 -20,20 0,11.06011 8.939897,20 20,20 11.060103,0 20,-8.93989 20,-20 0,-11.06011 -8.939897,-20 -20,-20 z"
+       transform="translate(0,-61)"
+       id="path3950"
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m 68,117 c -10.515528,0 -19,8.48447 -19,19 0,10.51553 8.484472,19 19,19 10.515528,0 19,-8.48447 19,-19 0,-10.51553 -8.484472,-19 -19,-19 z"
+       transform="translate(0,-61)"
+       id="path3946"
+       style="opacity:0.15;fill:#000000;fill-opacity:1;stroke:none;display:inline" />
+    <rect
+       width="36"
+       height="36"
+       rx="18"
+       ry="18"
+       x="50"
+       y="118"
+       transform="translate(0,-61)"
+       clip-path="url(#clipPath3871-0)"
+       id="rect3859-5"
+       style="opacity:0.31000001;fill:#000000;fill-opacity:1;stroke:none;display:inline" />
+    <g
+       transform="matrix(0.3050653,0,0,0.3050653,48.475572,54.368272)"
+       id="g2932"
+       style="display:inline">
+      <path
+         d="M 64,36.75 C 48.959918,36.75 36.750001,48.95992 36.75,64 36.75,79.040081 48.959916,91.250003 64,91.25 79.040082,91.25 91.250003,79.040082 91.25,64 91.25,48.959919 79.04008,36.750002 64,36.75 z M 64,56 c 4.415999,-10e-7 8,3.584 8,8 0,4.416 -3.583999,8 -8,8 -4.416003,0 -8,-3.584 -8,-8 10e-7,-4.416001 3.583999,-8 8,-8 z"
+         inkscape:connector-curvature="0"
+         id="path3307"
+         style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+      <path
+         d="m 92.579506,61.92226 a 32.685513,27.208481 0 1 1 -65.371025,0 32.685513,27.208481 0 1 1 65.371025,0 z"
+         transform="matrix(0,0.5048109,-0.6064286,0,101.55143,33.764859)"
+         id="path3328"
+         style="opacity:0.5;fill:url(#radialGradient3348);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3336);stroke-width:5.92451763;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         d="m 92.579506,61.92226 a 32.685513,27.208481 0 1 1 -65.371025,0 32.685513,27.208481 0 1 1 65.371025,0 z"
+         transform="matrix(0,0.2294595,-0.2756492,0,81.068821,50.256754)"
+         id="path3352"
+         style="opacity:0.6;fill:none;stroke:url(#linearGradient3368);stroke-width:13.03394222;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         d="M 64,5 C 31.431999,5 5,31.432001 5,64 5,96.567999 31.432,123 64,123 96.568001,123 123,96.567999 123,64 123,31.432001 96.568001,5 64,5 z m 0,38 c 11.592,-2e-6 21,9.408001 21,21 10e-7,11.591999 -9.408,21 -21,21 -11.592,-2e-6 -21,-9.408001 -21,-21 0,-11.591999 9.408,-21 21,-21 z"
+         inkscape:connector-curvature="0"
+         id="path3170"
+         style="fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+      <path
+         d="M 93.5,13.257858 C 65.295284,-3.0261424 29.188501,6.6486424 12.904501,34.853357 -3.3794983,63.058071 6.2952846,99.164856 34.5,115.44886 c 28.204716,16.284 64.311499,6.60921 80.5955,-21.595503 C 131.3795,65.648643 121.70472,29.541859 93.5,13.257858 z m -19,32.908966 C 84.538967,51.962822 87.982533,64.814391 82.186533,74.853357 76.390535,84.892323 63.538966,88.33589 53.5,82.53989 43.461035,76.743889 40.017467,63.892323 45.813467,53.853357 51.609466,43.814391 64.461034,40.370824 74.5,46.166824 z"
+         inkscape:connector-curvature="0"
+         id="path3230"
+         style="opacity:0.8;fill:url(#linearGradient3239);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+      <path
+         d="m 92.579506,61.92226 a 32.685513,27.208481 0 1 1 -65.371025,0 32.685513,27.208481 0 1 1 65.371025,0 z"
+         transform="matrix(0.7648649,0,0,0.9188312,18.189187,7.1038953)"
+         id="path3304"
+         style="opacity:0.15;fill:none;stroke:#000000;stroke-width:15.640728;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <g
+         transform="matrix(0.6142404,-0.789119,0.789119,0.6142404,-148.12977,-20.014381)"
+         id="g3289"
+         style="display:inline">
+        <g
+           clip-path="url(#clipPath3271)"
+           id="g3266">
+          <path
+             d="M 74.118027,277.11735 C 106.19881,271.5322 127.70249,240.96275 122.11734,208.88198 116.5322,176.8012 85.962749,155.29751 53.881978,160.88266 21.801203,166.46781 0.29750806,197.03725 5.8826547,229.11804 11.4678,261.19881 42.037246,282.70249 74.118027,277.11735 z m -6.516698,-37.43151 c -11.41858,1.98793 -22.299227,-5.66593 -24.287158,-17.08451 -1.987941,-11.41857 5.665921,-22.29923 17.084499,-24.28716 11.41858,-1.98793 22.299233,5.66593 24.28717,17.08451 1.987924,11.41857 -5.665932,22.29923 -17.084511,24.28716 z"
+             inkscape:connector-curvature="0"
+             id="path3259"
+             style="fill:url(#linearGradient3299);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+          <path
+             d="M 94.776853,269.3268 C 122.55724,252.33798 131.31561,216.00355 114.32679,188.22315 97.337964,160.44278 61.003543,151.6844 33.223145,168.67322 5.4427579,185.66204 -3.3156068,221.99648 13.673211,249.77686 30.662035,277.55725 66.996455,286.31562 94.776853,269.3268 z M 74.954469,236.91293 c -9.88793,6.04687 -22.820523,2.92947 -28.867393,-6.95846 -6.046863,-9.88793 -2.929476,-22.82053 6.958454,-28.86739 9.887938,-6.04686 22.820537,-2.92949 28.867401,6.95845 6.046855,9.88793 2.929476,22.82053 -6.958462,28.8674 z"
+             inkscape:connector-curvature="0"
+             id="path3231"
+             style="fill:url(#linearGradient3301);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+          <path
+             d="m 36.153689,271.00561 c 28.707102,15.37117 64.480751,4.54779 79.851921,-24.1593 15.37116,-28.70708 4.5478,-64.48074 -24.159308,-79.85191 -28.707087,-15.37116 -64.480736,-4.5478 -79.851909,24.15931 -15.371173,28.70708 -4.5478122,64.48073 24.159296,79.8519 z m 17.934913,-33.49512 c -10.217773,-5.4711 -14.070163,-18.2041 -8.599064,-28.42189 5.471077,-10.21777 18.204079,-14.07015 28.421859,-8.59906 10.217787,5.47108 14.07017,18.2041 8.599071,28.42186 -5.471084,10.21778 -18.204093,14.07016 -28.421866,8.59909 z"
+             inkscape:connector-curvature="0"
+             id="path3243"
+             style="fill:url(#linearGradient3303);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+        </g>
+        <g
+           transform="matrix(1,0,0,-1,0,438.00336)"
+           clip-path="url(#clipPath3271)"
+           id="g3275">
+          <path
+             d="M 74.118027,277.11735 C 106.19881,271.5322 127.70249,240.96275 122.11734,208.88198 116.5322,176.8012 85.962749,155.29751 53.881978,160.88266 21.801203,166.46781 0.29750806,197.03725 5.8826547,229.11804 11.4678,261.19881 42.037246,282.70249 74.118027,277.11735 z m -6.516698,-37.43151 c -11.41858,1.98793 -22.299227,-5.66593 -24.287158,-17.08451 -1.987941,-11.41857 5.665921,-22.29923 17.084499,-24.28716 11.41858,-1.98793 22.299233,5.66593 24.28717,17.08451 1.987924,11.41857 -5.665932,22.29923 -17.084511,24.28716 z"
+             inkscape:connector-curvature="0"
+             id="path3277"
+             style="fill:url(#linearGradient3305);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+          <path
+             d="M 94.776853,269.3268 C 122.55724,252.33798 131.31561,216.00355 114.32679,188.22315 97.337964,160.44278 61.003543,151.6844 33.223145,168.67322 5.4427579,185.66204 -3.3156068,221.99648 13.673211,249.77686 30.662035,277.55725 66.996455,286.31562 94.776853,269.3268 z M 74.954469,236.91293 c -9.88793,6.04687 -22.820523,2.92947 -28.867393,-6.95846 -6.046863,-9.88793 -2.929476,-22.82053 6.958454,-28.86739 9.887938,-6.04686 22.820537,-2.92949 28.867401,6.95845 6.046855,9.88793 2.929476,22.82053 -6.958462,28.8674 z"
+             inkscape:connector-curvature="0"
+             id="path3279"
+             style="fill:url(#linearGradient3307);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+          <path
+             d="m 36.153689,271.00561 c 28.707102,15.37117 64.480751,4.54779 79.851921,-24.1593 15.37116,-28.70708 4.5478,-64.48074 -24.159308,-79.85191 -28.707087,-15.37116 -64.480736,-4.5478 -79.851909,24.15931 -15.371173,28.70708 -4.5478122,64.48073 24.159296,79.8519 z m 17.934913,-33.49512 c -10.217773,-5.4711 -14.070163,-18.2041 -8.599064,-28.42189 5.471077,-10.21777 18.204079,-14.07015 28.421859,-8.59906 10.217787,5.47108 14.07017,18.2041 8.599071,28.42186 -5.471084,10.21778 -18.204093,14.07016 -28.421866,8.59909 z"
+             inkscape:connector-curvature="0"
+             id="path3281"
+             style="fill:url(#linearGradient3309);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g4106-7"
+       style="display:inline">
+      <path
+         d="m 68,56 c -9.941125,0 -18,8.058875 -18,18 0,3.6617 1.09067,7.063961 2.96875,9.90625 C 51.722125,81.541769 51,78.858787 51,76 c 0,-9.388841 7.611159,-17 17,-17 9.388841,0 17,7.611159 17,17 0,2.858787 -0.722125,5.541769 -1.96875,7.90625 C 84.90933,81.063961 86,77.6617 86,74 86,64.058875 77.941125,56 68,56 z"
+         inkscape:connector-curvature="0"
+         id="path3846-2"
+         style="opacity:0.3;fill:url(#linearGradient3857-6-8);fill-opacity:1;stroke:none" />
+      <path
+         d="m 68,56 c -9.94112,0 -18,8.05887 -18,18 0,0.168593 0.02664,0.33252 0.03125,0.5 C 50.298212,64.79197 58.227473,57 68,57 c 9.73052,0 17.63723,7.725255 17.96875,17.375 l 0,-1 C 85.63723,63.725255 77.73052,56 68,56 z"
+         inkscape:connector-curvature="0"
+         id="path4097-7"
+         style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;display:inline" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
It looks like we need to make more changes to icon handling but that can be done
when we port to gtk3. Do this for now so we see the proper icon in
mate-control-center