### PR TITLE
fix runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,9 @@ Package: mintsources
 Architecture: all
 Essential: yes
 Depends: python3-apt,
+         python3-gi,
          python3-pycurl,
-         python3-xapp,
+         mint-common (>= 1.3.0),
          gir1.2-gdkpixbuf-2.0,
          gir1.2-glib-2.0,
          gir1.2-gtk-3.0,


### PR DESCRIPTION
- xapp isn't needed after 5a299f7d212426134d66d93e9704248051228de2
- mint-common 1.3.0 is needed after "migration to aptdaemon"
- python3-gi is needed for "import gi"