### PR TITLE
Add option to enable dbgsym repos.

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -570,6 +570,41 @@
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Debug symbols</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="debug_symbol_switch">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/usr/share/mintsources/cindy/official-dbgsym-repositories.list
+++ b/usr/share/mintsources/cindy/official-dbgsym-repositories.list
@@ -1,0 +1,1 @@
+deb http://debug.mirrors.debian.org/debian-debug/ $basecodename-debug main 

--- a/usr/share/mintsources/tara/official-dbgsym-repositories.list
+++ b/usr/share/mintsources/tara/official-dbgsym-repositories.list
@@ -1,0 +1,3 @@
+deb http://ddebs.ubuntu.com $basecodename main restricted universe multiverse
+deb http://ddebs.ubuntu.com $basecodename-updates main restricted universe multiverse
+deb http://ddebs.ubuntu.com $basecodename-proposed main restricted universe multiverse 


### PR DESCRIPTION
Add option to enable dbgsym repositories.

According to [this](https://wiki.ubuntu.com/Debug%20Symbol%20Packages), there's a signing key or a package that needs installed, I'm not sure the best way to do this (since an additional key appears only needed for ubuntu (lm), not [debian](https://wiki.debian.org/AutomaticDebugPackages)(lmde3).  In the mintsources.conf for tara?