### PR TITLE
Fix for ppa'a with descriptions containing non unicode characters

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -138,7 +138,7 @@ def add_repository_via_cli(line, codename, forceYes, use_ppas):
 
         print(_("You are about to add the following PPA:"))
         if ppa_info["description"] is not None:
-            print(" %s" % (ppa_info["description"]))
+            print(" %s" % (str(ppa_info["description"]).encode("utf-8","ignore")))
         print(_(" More info: %s") % str(ppa_info["web_link"]))
 
         if sys.stdin.isatty():


### PR DESCRIPTION
adding repository 'ppa:graphics-drivers/ppa' while doing isorespin of Mint 19 results in exception:
Traceback (most recent call last):
  File "/usr/lib/linuxmint/mintSources/mintSources.py", line 1557, in <module>
    add_repository_via_cli(ppa_line, codename, options.forceYes, use_ppas)
  File "/usr/lib/linuxmint/mintSources/mintSources.py", line 141, in add_repository_via_cli
    print(" %s" % (ppa_info["description"]))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1000-1003: ordinal not in range(128)