### PR TITLE
Allow UTF-8 characters in mirrorsfile regardless of current locale.

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -931,7 +931,7 @@ class Application(object):
     def read_mirror_list(self, path):
         mirror_list = []
         country_code = None
-        mirrorsfile = open(path, "r")
+        mirrorsfile = open(path, "r",encoding='utf-8')
         for line in mirrorsfile.readlines():
             line = line.strip()
             if line != "":


### PR DESCRIPTION
If locale implies ASCII (or probably any non-UTF8-encoding), reading mirrorsfile fails.  There should be explicit encoding parameter in open().

There are probably other bugs like this elsewhere.

See [discussion](https://github.com/linuxmint/mintsources/issues/127).