### PR TITLE
Fix issues with adding PPAs

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -159,10 +159,11 @@ def add_repository_via_cli(line, codename, forceYes, use_ppas):
         # Add the key if not in keyring
         add_new_key(ppa_info["signing_key_fingerprint"])
 
-        # Add the PPA in sources.list.d
+        # Add the PPA
+        sources_enabled = os.path.exists("/etc/apt/sources.list.d/official-source-repositories.list")
         with open(file, "w", encoding="utf-8", errors="ignore") as text_file:
             text_file.write("%s\n" % deb_line)
-            text_file.write("%s\n" % debsrc_line)
+            text_file.write("%s%s\n" % ("" if sources_enabled else "# ", debsrc_line))
 
     elif line.startswith("deb ") | line.startswith("http"):
         line = expand_http_line(line, codename)

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -186,7 +186,7 @@ def add_new_key(key):
 
 def add_key_remote(key):
     try:
-        subprocess.run(["apt-key", "adv", "--keyserver", "keyserver.ubuntu.com", "--recv-keys", key], check=True)
+        subprocess.run(["apt-key", "adv", "--keyserver", "hkps://keyserver.ubuntu.com:443", "--recv-keys", key], check=True)
     except subprocess.CalledProcessError:
         return False
     return True

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -178,12 +178,13 @@ def add_repository_via_cli(line, codename, forceYes, use_ppas):
                 f.write("%s\n" % line)
 
 def add_new_key(key):
-    """ Add the key if not in keyring """
-    keys = subprocess.run(["apt-key","--quiet", "adv","--with-colons", "--batch",\
-        "--fixed-list-mode", "--list-keys"], stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL).stdout.decode().split(":")
-    if not key in keys:
-        add_key_remote(key)
+    # """ Add the key if not in keyring """
+    # keys = subprocess.run(["apt-key","--quiet", "adv","--with-colons", "--batch",\
+    #     "--fixed-list-mode", "--list-keys"], stdout=subprocess.PIPE,
+    #         stderr=subprocess.DEVNULL).stdout.decode().split(":")
+    # if not key in keys:
+    #     add_key_remote(key)
+    add_key_remote(key)
 
 def add_key_remote(key):
     try:

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -1206,19 +1206,19 @@ class Application(object):
                     text_file.write("%s%s\n" % ("" if sources_enabled else "# ", debsrc_line))
 
                 # Add the package line to the UI or replace it if it exists
-                def add_to_ui(line):
+                def add_to_ui(line, selected=True):
                     repo = next((repo for repo in self.ppas if (repo.line == line and repo.file == file)), None)
                     if repo:
                         iter = next((item.iter for item in self._ppa_model if line in self._ppa_model.get_value(item.iter, 2).split("\n")), None)
                         if iter:
                             self._ppa_model.remove(iter)
                         self.ppas.remove(repo)
-                    repository = Repository(self, line, file, True)
+                    repository = Repository(self, line, file, selected)
                     self.ppas.append(repository)
-                    tree_iter = self._ppa_model.append((repository, repository.selected, repository.get_ppa_name()))
+                    tree_iter = self._ppa_model.append((repository, selected, repository.get_ppa_name()))
 
                 add_to_ui(deb_line)
-                add_to_ui(debsrc_line)
+                add_to_ui(debsrc_line, sources_enabled)
 
                 self.enable_reload_button()
 

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -222,11 +222,11 @@ def get_ppa_info_from_lp(owner_name, ppa_name, base_codename):
 
     data = requests.get(lp_url)
     if not data.ok:
-        raise PPAException(_("PPA not found"))
+        raise PPAException(_("No valid PPA of this name was found."))
     try:
         json_data = data.json()
     except pycurl.error as e:
-        raise PPAException("%s %s: %s" % (_("Error reading"), lp_url, e))
+        raise PPAException(_("No valid PPA of this name was found."))
 
     # Make sure the PPA supports our base release
     repo_url = "http://ppa.launchpad.net/%s/%s/ubuntu/dists/%s" % (owner_name, ppa_name, base_codename)
@@ -1177,12 +1177,12 @@ class Application(object):
         if line:
             try:
                 if not line.startswith("ppa:") or line == default_line:
-                    raise ValueError("Invalid PPA name")
+                    raise ValueError(_("The name of the PPA you entered isn't formatted correctly."))
                 user, sep, ppa_name = line.split(":", 1)[1].partition("/")
                 ppa_name = ppa_name or "ppa"
                 ppa_info = get_ppa_info_from_lp(user, ppa_name, self.config["general"]["base_codename"])
-            except Exception as detail:
-                self.show_error_dialog(self._main_window, _("Cannot add PPA: '%s'.") % detail)
+            except Exception as error_msg:
+                self.show_error_dialog(self._main_window, error_msg)
                 return
 
             image = Gtk.Image()


### PR DESCRIPTION
- Fix #138 adding PPA sources via GUI, they are now only automatically enabled when official source code repos are enabled
  - ~~adding via CLI still adds them both as enabled since you cannot toggle the source repos via CLI~~ (CLI is the same now, my own reasoning didn't convince me anymore...)
- Prevent duplicate PPA entries in GUI when adding the same PPA twice
- Prevent unnecessarily retrieving the PPA key if already in keyring
- Better error handling of invalid PPA names, user now gets told if the PPA could not be found (instead of the cryptic message they're currently receiving)
- Fix an issue some users had with downloading PPA keys (keyserver timeout)