### PR TITLE
remove excessive trailing slash from deb.debian.org

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -999,7 +999,7 @@ class Application(object):
                             mirror = Mirror(country_code, url, name)
                             mirror_list.append(mirror)
         if path.endswith("Debian.mirrors"):
-            mirror = Mirror("WD", "http://deb.debian.org/debian/", "http://deb.debian.org/debian/")
+            mirror = Mirror("WD", "http://deb.debian.org/debian", "http://deb.debian.org/debian/")
             mirror_list.append(mirror)
         return mirror_list
 


### PR DESCRIPTION
avoids double slash in the sources list file