### PR TITLE
Clean up imports and fix ppa_browser arch detection along the way

### DIFF
--- a/usr/bin/mint-switch-to-local-mirror
+++ b/usr/bin/mint-switch-to-local-mirror
@@ -3,15 +3,18 @@
 #TODO: Factorize mirror detection/analysis code into mint-common
 # It's used in here, but also in mintsources itself, and in mintupdate...
 
-import os, sys
-import lsb_release
 import datetime
-import pycurl
-import json
-import urllib.request as urllibrequest
-import re
-import random
 import fileinput
+import json
+import os
+import random
+import re
+import sys
+import urllib.request as urllibrequest
+
+import lsb_release
+
+import pycurl
 
 MIRROR_LIST = "/usr/share/mint-mirrors/linuxmint.list"
 SOURCES_LIST = "/etc/apt/sources.list.d/official-package-repositories.list"

--- a/usr/bin/software-sources
+++ b/usr/bin/software-sources
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-import sys
 
 if os.getuid() != 0:
     subprocess.run(["pkexec", "/usr/bin/mintsources"])

--- a/usr/lib/linuxmint/mintSources/foreign_packages.py
+++ b/usr/lib/linuxmint/mintSources/foreign_packages.py
@@ -1,22 +1,21 @@
 #!/usr/bin/python3
-import os
-import sys
-import apt
-import gettext
-import tempfile
-import subprocess
-import mintcommon.aptdaemon
-import gi
-import locale
 
+import gettext
+import os
+import subprocess
+import sys
+
+import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Vte', '2.91')
 from gi.repository import Gtk, Vte, GLib
 
+import apt
+import mintcommon.aptdaemon
+
 # i18n
 APP = 'mintsources'
 LOCALE_DIR = "/usr/share/linuxmint/locale"
-locale.bindtextdomain(APP, LOCALE_DIR)
 gettext.bindtextdomain(APP, LOCALE_DIR)
 gettext.textdomain(APP)
 _ = gettext.gettext

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -18,9 +18,8 @@ import datetime
 from urllib.request import urlopen
 import requests
 from optparse import OptionParser
-import locale
 import mintcommon.aptdaemon
-import glob
+from glob import glob
 import apt_pkg
 import shutil
 import gi
@@ -39,7 +38,6 @@ additional_repositories_file = "/etc/apt/sources.list.d/additional-repositories.
 # i18n
 APP = 'mintsources'
 LOCALE_DIR = "/usr/share/linuxmint/locale"
-locale.bindtextdomain(APP, LOCALE_DIR)
 gettext.bindtextdomain(APP, LOCALE_DIR)
 gettext.textdomain(APP)
 _ = gettext.gettext
@@ -267,7 +265,7 @@ def expand_ppa_line(abrev, distro_codename):
     ppa_owner = abrev.split("/")[0]
     try:
         ppa_name = abrev.split("/")[1]
-    except IndexError:
+    except:
         ppa_name = "ppa"
     sourceslistd = "/etc/apt/sources.list.d"
     line = "deb http://ppa.launchpad.net/%s/%s/ubuntu %s main" % (ppa_owner, ppa_name, distro_codename)
@@ -282,7 +280,7 @@ def expand_http_line(line, distro_codename):
       apt-add-repository 'deb http://packages.medibuntu.org/ base_codename free non-free'
     """
     if not line.startswith("http"):
-      return line
+        return line
     repo = line.split()[0]
     try:
         areas = line.split(" ",1)[1]
@@ -610,7 +608,7 @@ class MirrorSelectionDialog(object):
                     if mirror in self.visible_mirrors:
                         url = self._mirrors_model.get_value(iter, MirrorSelectionDialog.MIRROR_URL_COLUMN)
                         self._speed_test (iter, url)
-            except Exception as e:
+            except:
                 pass # null types will occur here...
 
     def _get_speed_label(self, speed):
@@ -1059,7 +1057,7 @@ class Application(object):
         knownlines = set()
 
         # Parse official sources first
-        for listfile in glob.glob("/etc/apt/sources.list.d/official*.list"):
+        for listfile in glob("/etc/apt/sources.list.d/official*.list"):
             with open(listfile, encoding="utf-8", errors="ignore") as f:
                 lines = []
                 for line in f.readlines():
@@ -1070,7 +1068,7 @@ class Application(object):
 
         # Now parse other sources and remove any duplicates
         found_duplicates = False
-        for listfile in ["/etc/apt/sources.list"] + glob.glob("/etc/apt/sources.list.d/*.list"):
+        for listfile in ["/etc/apt/sources.list"] + glob("/etc/apt/sources.list.d/*.list"):
             if not listfile.startswith("/etc/apt/sources.list.d/official"):
                 with open(listfile, encoding="utf-8", errors="ignore") as f:
                     lines = []

--- a/usr/lib/linuxmint/mintSources/ppa_browser.py
+++ b/usr/lib/linuxmint/mintSources/ppa_browser.py
@@ -1,22 +1,20 @@
 #!/usr/bin/python3
-import os
-import sys
-import apt
+
 import gettext
-import tempfile
+import os
 import subprocess
-import mintcommon.aptdaemon
-import platform
-import locale
+import sys
+
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('GdkX11', '3.0') # Needed to get xid
-from gi.repository import Gtk, GdkX11
+from gi.repository import Gtk
+
+import apt
+import mintcommon.aptdaemon
 
 # i18n
 APP = 'mintsources'
 LOCALE_DIR = "/usr/share/linuxmint/locale"
-locale.bindtextdomain(APP, LOCALE_DIR)
 gettext.bindtextdomain(APP, LOCALE_DIR)
 gettext.textdomain(APP)
 _ = gettext.gettext
@@ -24,7 +22,7 @@ _ = gettext.gettext
 class PPA_Browser():
 
     def __init__(self, base_codename, ppa_owner, ppa_name):
-        if platform.machine() == "X86_64":
+        if os.uname().machine == "x86_64":
             architecture = "amd64"
         else:
             architecture = "i386"


### PR DESCRIPTION
Lots of unnecessary imports that had to go. edit: I reverted most of the cleanup to mintSources.py to make later PRs easier to merge.

While doing that I accidentally noticed that architecture detection in ppa_browser.py was broken at least on my machine due to incorrect capitalization, so I added a .lower() to fix it for all eventualities.

Depends on #134 and #147