### PR TITLE
Improve PPA retrieval error handling (including Ctrl+C), add timeout, drop urllib

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -16,7 +16,6 @@ from CountryInformation import CountryInformation
 import re
 import json
 import datetime
-from urllib.request import urlopen
 import requests
 from optparse import OptionParser
 import locale
@@ -698,7 +697,7 @@ class MirrorSelectionDialog(object):
 
         # Try to find out where we're located...
         try:
-            lookup = str(urlopen('http://geoip.ubuntu.com/lookup').read())
+            lookup = requests.get('http://geoip.ubuntu.com/lookup').text
             cur_country_code = re.search('<CountryCode>(.*)</CountryCode>', lookup).group(1)
             if cur_country_code == 'None': cur_country_code = None
         except Exception as detail:


### PR DESCRIPTION
More detailed and complete error handling, no longer printing a stack trace when the user presses Ctrl+C as instructed to cancel (!), no longer endlessly trying to connect in packet loss situations (I set a very generous timeout of 10 seconds between packets).

Also cleaning out some legacy code and consolidating libraries used (mintsources is currently using 3 different http libraries, with this we're down to 2, `pycurl` still needs to go).