### PR TITLE
Fix PPA browser not finding the correct package list

### DIFF
--- a/usr/lib/linuxmint/mintSources/ppa_browser.py
+++ b/usr/lib/linuxmint/mintSources/ppa_browser.py
@@ -23,18 +23,9 @@ _ = gettext.gettext
 
 class PPA_Browser():
 
-    def __init__(self, base_codename, ppa_owner, ppa_name):
-        if platform.machine() == "X86_64":
-            architecture = "amd64"
-        else:
-            architecture = "i386"
+    def __init__(self, ppa_file, ppa_owner, ppa_name):
         ppa_origin = "LP-PPA-%s-%s" % (ppa_owner, ppa_name)
         ppa_origin_simple = "LP-PPA-%s" % (ppa_owner)
-        ppa_file = "/var/lib/apt/lists/ppa.launchpad.net_%s_%s_ubuntu_dists_%s_main_binary-%s_Packages" % (ppa_owner, ppa_name, base_codename, architecture)
-
-        if not os.path.exists(ppa_file):
-            print ("%s not found!" % ppa_file)
-            sys.exit(1)
 
         self.packages_to_install = []
         self.packages_installed_from_ppa = []
@@ -128,8 +119,8 @@ class PPA_Browser():
         sys.exit(0)
 
 if __name__ == "__main__":
-    base_codename = sys.argv[1]
+    ppa_file = sys.argv[1]
     ppa_owner = sys.argv[2]
     ppa_name = sys.argv[3]
-    ppa_browser = PPA_Browser(base_codename, ppa_owner, ppa_name)
+    ppa_browser = PPA_Browser(ppa_file, ppa_owner, ppa_name)
     Gtk.main()


### PR DESCRIPTION
Currently the PPA browser hardcodes most of the package list file name, finding the correct name only by luck, and making it impossible to open PPAs not matching the expected pattern. This patch tries to properly determine the name and location of said file instead.