### PR TITLE
Rewrite key retrieval and storage for better compatibility and performance

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -311,7 +311,8 @@ class AddAptKey(object):
         cmd.extend(args)
         return subprocess.run(cmd, input=data, stdout=subprocess.PIPE, check=True).stdout
 
-    def retrieve_key_from_lp(self, ppa_info):
+    @staticmethod
+    def retrieve_key_from_lp(ppa_info):
         """ Retrieves they key for a PPA directly from launchpad.net """
         signing_key_fingerprint = ppa_info["signing_key_fingerprint"]
         try:

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -347,7 +347,7 @@ class AddAptKey(object):
         # Unfortunately we also have to support key ids, not just full fingerprints
         if expected_fingerprint != fingerprints[0][-(len(expected_fingerprint)):]:
             return False
-        return True
+        return fingerprints[0]
 
     def add_ppa_key(self, ppa_info):
         """ Retrieve the signing key corresponding to 'ppa_info' and add it. """
@@ -371,7 +371,8 @@ class AddAptKey(object):
         if not minimal_key:
             raise Exception("GPG failed to return the minimized key.")
 
-        if not self.verify_fingerprint(minimal_key, fingerprint):
+        fingerprint = self.verify_fingerprint(minimal_key, fingerprint)
+        if not fingerprint:
             raise Exception(f"Received key with unexpected fingerprint.")
 
         filename = os.path.join(self.apt_trustedparts, encode(fingerprint) + ".gpg")


### PR DESCRIPTION
Keys are now retrieved via https from either launchpad directly for newly added PPAs or from Ubuntu's keyserver, and stored as individual armored key files rather than added to the keyring.

This ends usage of the deprecated problematic `apt-key` for key retrieval. It's also much faster. 

Remaining apt-key usage will be addressed in a future PR.

This also cleans up some imports and fixes a type bug.

Closes #128 for sure, even though we never established what the actual problem was.