### PR TITLE
Fix repo_malformed and repo_exists to support file:/ repositories

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -199,14 +199,14 @@ def add_key_remote(key):
     return True
 
 def repo_malformed(line):
-    r = re.compile(r'(?:deb|deb-src)\s+\w+://.+?/?\s+\S+')
+    r = re.compile(r'(?:deb|deb-src)\s+\w+:/\S+?/?\s+\S+')
     match_line = r.match(line)
     if not match_line:
         return True
     return False
 
 def repo_exists(line):
-    r = re.compile(r'^[#\s]*(\S+)\s*(?:\[.*\])? \w+://(.+?)/? (.+)')
+    r = re.compile(r'^[#\s]*(\S+)\s*(?:\[.*\])? \w+:/(\S+?)/? (.+)')
     match_line = r.match(line.strip())
     if match_line:
         repositories = SourcesList().list


### PR DESCRIPTION
The file:/ prefix uses only a single slash.