### PR TITLE
foreign_packages.py: Use default shell instead of /bin/dash, don't depend on dash

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,6 @@ Depends: python3-apt,
          gir1.2-pango-1.0,
          gir1.2-vte-2.91,
          gir1.2-xapp-1.0,
-         dash,
          iso-flag-png,
          lsb-release
 Replaces: software-properties-common (<< 1),

--- a/usr/lib/linuxmint/mintSources/foreign_packages.py
+++ b/usr/lib/linuxmint/mintSources/foreign_packages.py
@@ -175,7 +175,7 @@ class Foreign_Browser():
         if self.downgrade_mode:
             self.builder.get_object("stack1").set_visible_child_name("vte")
             terminal = Vte.Terminal()
-            terminal.spawn_sync(Vte.PtyFlags.DEFAULT, os.environ['HOME'], ["/bin/dash"], [], GLib.SpawnFlags.DO_NOT_REAP_CHILD, None, None,)
+            terminal.spawn_sync(Vte.PtyFlags.DEFAULT, os.environ['HOME'], [os.environ["SHELL"]], [], GLib.SpawnFlags.DO_NOT_REAP_CHILD, None, None,)
             terminal.feed_child("apt-get install %s\n" % " ".join(foreign_packages), -1)
             terminal.show()
             self.builder.get_object("box_vte").add(terminal)


### PR DESCRIPTION
No reason to force a specific shell here