### PR TITLE
allow for window controls on the left

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -274,7 +274,6 @@
         <property name="title">Software Sources</property>
         <property name="has_subtitle">False</property>
         <property name="show_close_button">True</property>
-        <property name="decoration_layout">:minimize,maximize,close</property>
         <child>
           <placeholder/>
         </child>


### PR DESCRIPTION
Window controls wouldn't move to the left if button layout so configured by user; decoration_layout=:minimize,maximize,close was blocking that. Removing it fixes that and show_close_button=True already enables those buttons.