### PR TITLE
apt-add-repository: allow deb options

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -208,7 +208,7 @@ def add_key_remote(key):
     return True
 
 def repo_malformed(line):
-    r = re.compile(r'(?:deb|deb-src)\s+\w+:/\S+?/?\s+\S+')
+    r = re.compile(r'(?:deb|deb-src)\s+(?:\[[^\]]+\])?\s+\w+:/\S+?/?\s+\S+')
     match_line = r.match(line)
     if not match_line:
         return True


### PR DESCRIPTION
Update the RE to allow for [deb options](https://manpages.debian.org/buster/apt/sources.list.5.en.html#THE_DEB_AND_DEB-SRC_TYPES:_OPTIONS) like [arch=amd64] in the repository line when adding repository through apt-add-repository.

This fixes #179 and #188.