### PR TITLE
Update mintSources.py

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -213,7 +213,6 @@ def add_key_remote(key):
                 #     print "Not a real URL"
                 # is unclear to me about the fault message
                 proxy=["--keyserver-options", "http-proxy=%s" % os.environ.get('http_proxy')]
-                
         subprocess.run(["apt-key", "adv", "--keyserver", "hkps://keyserver.ubuntu.com:443"] + proxy + ["--recv-keys", key], check=True)
     except subprocess.CalledProcessError:
         return False

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -205,6 +205,13 @@ def add_key_remote(key):
         proxy = []
         if os.environ.get('http_proxy') is not None:
             if os.environ.get('http_proxy') != "":
+                # might be an good idea to check the environment variable content for url only ....
+                # simple way could be
+                # try:
+                #     urllib.urlopen(url)
+                # except IOError:
+                #     print "Not a real URL"
+                # is unclear to me about the fault message
                 proxy=["--keyserver-options", "http-proxy=%s" % os.environ.get('http_proxy')]
                 
         subprocess.run(["apt-key", "adv", "--keyserver", "hkps://keyserver.ubuntu.com:443"] + proxy + ["--recv-keys", key], check=True)

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -203,8 +203,10 @@ def add_new_key(key):
 def add_key_remote(key):
     try:
         proxy = []
-        if (os.environ.get('http_proxy') != ""):
-            proxy=["--keyserver-options", "http-proxy=%s" % os.environ.get('http_proxy')]
+        if os.environ.get('http_proxy') is not None:
+            if os.environ.get('http_proxy') != "":
+                proxy=["--keyserver-options", "http-proxy=%s" % os.environ.get('http_proxy')]
+                
         subprocess.run(["apt-key", "adv", "--keyserver", "hkps://keyserver.ubuntu.com:443"] + proxy + ["--recv-keys", key], check=True)
     except subprocess.CalledProcessError:
         return False

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -202,7 +202,10 @@ def add_new_key(key):
 
 def add_key_remote(key):
     try:
-        subprocess.run(["apt-key", "adv", "--keyserver", "hkps://keyserver.ubuntu.com:443", "--recv-keys", key], check=True)
+        proxy = []
+        if (os.environ.get('http_proxy') != ""):
+            proxy=["--keyserver-options", "http-proxy=%s" % os.environ.get('http_proxy')]
+        subprocess.run(["apt-key", "adv", "--keyserver", "hkps://keyserver.ubuntu.com:443"] + proxy + ["--recv-keys", key], check=True)
     except subprocess.CalledProcessError:
         return False
     return True


### PR DESCRIPTION
use http_proxy environment for gpg key install....

I just added the check for an configured http_proxy to add the keyserver option for the proxy