### PR TITLE
Add NetworkNeighbors

### DIFF
--- a/usr/lib/linuxmint/mintSources/countries.json
+++ b/usr/lib/linuxmint/mintSources/countries.json
@@ -45,6 +45,7 @@
 		"demonym": "Aruban",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 180
 	},
 	{
@@ -99,6 +100,7 @@
 		"demonym": "Afghan",
 		"landlocked": true,
 		"borders": ["IRN", "PAK", "TKM", "UZB", "TJK", "CHN"],
+		"networkNeighbors": [],
 		"area": 652230
 	},
 	{
@@ -143,6 +145,7 @@
 		"demonym": "Angolan",
 		"landlocked": false,
 		"borders": ["COG", "COD", "ZMB", "NAM"],
+		"networkNeighbors": [],
 		"area": 1246700
 	},
 	{
@@ -186,6 +189,7 @@
 		"demonym": "Anguillian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 91
 	},
 	{
@@ -229,6 +233,7 @@
 		"demonym": "\u00c5landish",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 1580
 	},
 	{
@@ -273,6 +278,7 @@
 		"demonym": "Albanian",
 		"landlocked": false,
 		"borders": ["MNE", "GRC", "MKD", "KOS"],
+		"networkNeighbors": [],
 		"area": 28748
 	},
 	{
@@ -317,6 +323,7 @@
 		"demonym": "Andorran",
 		"landlocked": true,
 		"borders": ["FRA", "ESP"],
+		"networkNeighbors": [],
 		"area": 468
 	},
 	{
@@ -360,6 +367,7 @@
 		"demonym": "Emirati",
 		"landlocked": false,
 		"borders": ["OMN", "SAU"],
+		"networkNeighbors": [],
 		"area": 83600
 	},
 	{
@@ -409,6 +417,7 @@
 		"demonym": "Argentinean",
 		"landlocked": false,
 		"borders": ["BOL", "BRA", "CHL", "PRY", "URY"],
+		"networkNeighbors": [],
 		"area": 2780400
 	},
 	{
@@ -458,6 +467,7 @@
 		"demonym": "Armenian",
 		"landlocked": true,
 		"borders": ["AZE", "GEO", "IRN", "TUR"],
+		"networkNeighbors": [],
 		"area": 29743
 	},
 	{
@@ -506,6 +516,7 @@
 		"demonym": "American Samoan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 199
 	},
 	{
@@ -543,6 +554,7 @@
 		"demonym": "Antarctican",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 14000000
 	},
 	{
@@ -586,6 +598,7 @@
 		"demonym": "French",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 7747
 	},
 	{
@@ -630,6 +643,7 @@
 		"demonym": "Antiguan, Barbudan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 442
 	},
 	{
@@ -674,6 +688,7 @@
 		"demonym": "Australian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 7692024
 	},
 	{
@@ -718,6 +733,7 @@
 		"demonym": "Austrian",
 		"landlocked": true,
 		"borders": ["CZE", "DEU", "HUN", "ITA", "LIE", "SVK", "SVN", "CHE"],
+		"networkNeighbors": [],
 		"area": 83871
 	},
 	{
@@ -767,6 +783,7 @@
 		"demonym": "Azerbaijani",
 		"landlocked": true,
 		"borders": ["ARM", "GEO", "IRN", "RUS", "TUR"],
+		"networkNeighbors": [],
 		"area": 86600
 	},
 	{
@@ -816,6 +833,7 @@
 		"demonym": "Burundian",
 		"landlocked": true,
 		"borders": ["COD", "RWA", "TZA"],
+		"networkNeighbors": [],
 		"area": 27834
 	},
 	{
@@ -870,6 +888,7 @@
 		"demonym": "Belgian",
 		"landlocked": false,
 		"borders": ["FRA", "DEU", "LUX", "NLD"],
+		"networkNeighbors": [],
 		"area": 30528
 	},
 	{
@@ -914,6 +933,7 @@
 		"demonym": "Beninese",
 		"landlocked": false,
 		"borders": ["BFA", "NER", "NGA", "TGO"],
+		"networkNeighbors": [],
 		"area": 112622
 	},
 	{
@@ -958,6 +978,7 @@
 		"demonym": "Burkinabe",
 		"landlocked": true,
 		"borders": ["BEN", "CIV", "GHA", "MLI", "NER", "TGO"],
+		"networkNeighbors": [],
 		"area": 272967
 	},
 	{
@@ -1002,6 +1023,7 @@
 		"demonym": "Bangladeshi",
 		"landlocked": false,
 		"borders": ["MMR", "IND"],
+		"networkNeighbors": [],
 		"area": 147570
 	},
 	{
@@ -1046,6 +1068,7 @@
 		"demonym": "Bulgarian",
 		"landlocked": false,
 		"borders": ["GRC", "MKD", "ROU", "SRB", "TUR"],
+		"networkNeighbors": [],
 		"area": 110879
 	},
 	{
@@ -1090,6 +1113,7 @@
 		"demonym": "Bahraini",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 765
 	},
 	{
@@ -1134,6 +1158,7 @@
 		"demonym": "Bahamian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 13943
 	},
 	{
@@ -1188,6 +1213,7 @@
 		"demonym": "Bosnian, Herzegovinian",
 		"landlocked": false,
 		"borders": ["HRV", "MNE", "SRB"],
+		"networkNeighbors": [],
 		"area": 51209
 	},
 	{
@@ -1231,6 +1257,7 @@
 		"demonym": "Saint Barth\u00e9lemy Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 21
 	},
 	{
@@ -1280,6 +1307,7 @@
 		"demonym": "Belarusian",
 		"landlocked": true,
 		"borders": ["LVA", "LTU", "POL", "RUS", "UKR"],
+		"networkNeighbors": [],
 		"area": 207600
 	},
 	{
@@ -1334,6 +1362,7 @@
 		"demonym": "Belizean",
 		"landlocked": false,
 		"borders": ["GTM", "MEX"],
+		"networkNeighbors": [],
 		"area": 22966
 	},
 	{
@@ -1378,6 +1407,7 @@
 		"demonym": "Bermudian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 54
 	},
 	{
@@ -1437,6 +1467,7 @@
 		"demonym": "Bolivian",
 		"landlocked": true,
 		"borders": ["ARG", "BRA", "CHL", "PRY", "PER"],
+		"networkNeighbors": [],
 		"area": 1098581
 	},
 	{
@@ -1481,6 +1512,7 @@
 		"demonym": "Brazilian",
 		"landlocked": false,
 		"borders": ["ARG", "BOL", "COL", "GUF", "GUY", "PRY", "PER", "SUR", "URY", "VEN"],
+		"networkNeighbors": [],
 		"area": 8515767
 	},
 	{
@@ -1525,6 +1557,7 @@
 		"demonym": "Barbadian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 430
 	},
 	{
@@ -1569,6 +1602,7 @@
 		"demonym": "Bruneian",
 		"landlocked": false,
 		"borders": ["MYS"],
+		"networkNeighbors": [],
 		"area": 5765
 	},
 	{
@@ -1613,6 +1647,7 @@
 		"demonym": "Bhutanese",
 		"landlocked": true,
 		"borders": ["CHN", "IND"],
+		"networkNeighbors": [],
 		"area": 38394
 	},
 	{
@@ -1656,6 +1691,7 @@
 		"demonym": "",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 49
 	},
 	{
@@ -1704,6 +1740,7 @@
 		"demonym": "Motswana",
 		"landlocked": true,
 		"borders": ["NAM", "ZAF", "ZMB", "ZWE"],
+		"networkNeighbors": [],
 		"area": 582000
 	},
 	{
@@ -1753,6 +1790,7 @@
 		"demonym": "Central African",
 		"landlocked": true,
 		"borders": ["CMR", "TCD", "COD", "COG", "SSD", "SDN"],
+		"networkNeighbors": [],
 		"area": 622984
 	},
 	{
@@ -1802,6 +1840,7 @@
 		"demonym": "Canadian",
 		"landlocked": false,
 		"borders": ["USA"],
+		"networkNeighbors": [],
 		"area": 9984670
 	},
 	{
@@ -1846,6 +1885,7 @@
 		"demonym": "Cocos Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 14
 	},
 	{
@@ -1904,6 +1944,7 @@
 		"demonym": "Swiss",
 		"landlocked": true,
 		"borders": ["AUT", "FRA", "ITA", "LIE", "DEU"],
+		"networkNeighbors": [],
 		"area": 41284
 	},
 	{
@@ -1948,6 +1989,7 @@
 		"demonym": "Chilean",
 		"landlocked": false,
 		"borders": ["ARG", "BOL", "PER"],
+		"networkNeighbors": [],
 		"area": 756102
 	},
 	{
@@ -1992,6 +2034,7 @@
 		"demonym": "Chinese",
 		"landlocked": false,
 		"borders": ["AFG", "BTN", "MMR", "HKG", "IND", "KAZ", "PRK", "KGZ", "LAO", "MAC", "MNG", "PAK", "RUS", "TJK", "VNM"],
+		"networkNeighbors": [],
 		"area": 9706961
 	},
 	{
@@ -2035,6 +2078,7 @@
 		"demonym": "Ivorian",
 		"landlocked": false,
 		"borders": ["BFA", "GHA", "GIN", "LBR", "MLI"],
+		"networkNeighbors": [],
 		"area": 322463
 	},
 	{
@@ -2084,6 +2128,7 @@
 		"demonym": "Cameroonian",
 		"landlocked": false,
 		"borders": ["CAF", "TCD", "COG", "GNQ", "GAB", "NGA"],
+		"networkNeighbors": [],
 		"area": 475442
 	},
 	{
@@ -2148,6 +2193,7 @@
 		"demonym": "Congolese",
 		"landlocked": false,
 		"borders": ["AGO", "BDI", "CAF", "COG", "RWA", "SSD", "TZA", "UGA", "ZMB"],
+		"networkNeighbors": [],
 		"area": 2344858
 	},
 	{
@@ -2202,6 +2248,7 @@
 		"demonym": "Congolese",
 		"landlocked": false,
 		"borders": ["AGO", "CMR", "CAF", "COD", "GAB"],
+		"networkNeighbors": [],
 		"area": 342000
 	},
 	{
@@ -2251,6 +2298,7 @@
 		"demonym": "Cook Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 236
 	},
 	{
@@ -2295,6 +2343,7 @@
 		"demonym": "Colombian",
 		"landlocked": false,
 		"borders": ["BRA", "ECU", "PAN", "PER", "VEN"],
+		"networkNeighbors": [],
 		"area": 1141748
 	},
 	{
@@ -2349,6 +2398,7 @@
 		"demonym": "Comoran",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 1862
 	},
 	{
@@ -2393,6 +2443,7 @@
 		"demonym": "Cape Verdian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 4033
 	},
 	{
@@ -2437,6 +2488,7 @@
 		"demonym": "Costa Rican",
 		"landlocked": false,
 		"borders": ["NIC", "PAN"],
+		"networkNeighbors": [],
 		"area": 51100
 	},
 	{
@@ -2481,6 +2533,7 @@
 		"demonym": "Cuban",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 109884
 	},
 	{
@@ -2529,6 +2582,7 @@
 		"demonym": "Dutch",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 444
 	},
 	{
@@ -2573,6 +2627,7 @@
 		"demonym": "Christmas Island",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 135
 	},
 	{
@@ -2617,6 +2672,7 @@
 		"demonym": "Caymanian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 264
 	},
 	{
@@ -2666,6 +2722,7 @@
 		"demonym": "Cypriot",
 		"landlocked": false,
 		"borders": ["GBR"],
+		"networkNeighbors": [],
 		"area": 9251
 	},
 	{
@@ -2715,6 +2772,7 @@
 		"demonym": "Czech",
 		"landlocked": true,
 		"borders": ["AUT", "DEU", "POL", "SVK"],
+		"networkNeighbors": [],
 		"area": 78865
 	},
 	{
@@ -2758,6 +2816,7 @@
 		"demonym": "German",
 		"landlocked": false,
 		"borders": ["AUT", "BEL", "CZE", "DNK", "FRA", "LUX", "NLD", "POL", "CHE"],
+		"networkNeighbors": [],
 		"area": 357114
 	},
 	{
@@ -2807,6 +2866,7 @@
 		"demonym": "Djibouti",
 		"landlocked": false,
 		"borders": ["ERI", "ETH", "SOM"],
+		"networkNeighbors": [],
 		"area": 23200
 	},
 	{
@@ -2851,6 +2911,7 @@
 		"demonym": "Dominican",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 751
 	},
 	{
@@ -2895,6 +2956,7 @@
 		"demonym": "Danish",
 		"landlocked": false,
 		"borders": ["DEU"],
+		"networkNeighbors": [],
 		"area": 43094
 	},
 	{
@@ -2939,6 +3001,7 @@
 		"demonym": "Dominican",
 		"landlocked": false,
 		"borders": ["HTI"],
+		"networkNeighbors": [],
 		"area": 48671
 	},
 	{
@@ -2983,6 +3046,7 @@
 		"demonym": "Algerian",
 		"landlocked": false,
 		"borders": ["TUN", "LBY", "NER", "ESH", "MRT", "MLI", "MAR"],
+		"networkNeighbors": ["FRA", "ITA", "ESP"],
 		"area": 2381741
 	},
 	{
@@ -3027,6 +3091,7 @@
 		"demonym": "Ecuadorean",
 		"landlocked": false,
 		"borders": ["COL", "PER"],
+		"networkNeighbors": [],
 		"area": 276841
 	},
 	{
@@ -3071,6 +3136,7 @@
 		"demonym": "Egyptian",
 		"landlocked": false,
 		"borders": ["ISR", "LBY", "SDN"],
+		"networkNeighbors": ["ITA", "TUR", "SAU"],
 		"area": 1002450
 	},
 	{
@@ -3125,6 +3191,7 @@
 		"demonym": "Eritrean",
 		"landlocked": false,
 		"borders": ["DJI", "ETH", "SDN"],
+		"networkNeighbors": [],
 		"area": 117600
 	},
 	{
@@ -3178,6 +3245,7 @@
 		"demonym": "Sahrawi",
 		"landlocked": false,
 		"borders": ["DZA", "MRT", "MAR"],
+		"networkNeighbors": [],
 		"area": 266000
 	},
 	{
@@ -3241,6 +3309,7 @@
 		"demonym": "Spanish",
 		"landlocked": false,
 		"borders": ["AND", "FRA", "GIB", "PRT", "MAR"],
+		"networkNeighbors": [],
 		"area": 505992
 	},
 	{
@@ -3285,6 +3354,7 @@
 		"demonym": "Estonian",
 		"landlocked": false,
 		"borders": ["LVA", "RUS"],
+		"networkNeighbors": [],
 		"area": 45227
 	},
 	{
@@ -3329,6 +3399,7 @@
 		"demonym": "Ethiopian",
 		"landlocked": true,
 		"borders": ["DJI", "ERI", "KEN", "SOM", "SSD", "SDN"],
+		"networkNeighbors": [],
 		"area": 1104300
 	},
 	{
@@ -3377,6 +3448,7 @@
 		"demonym": "Finnish",
 		"landlocked": false,
 		"borders": ["NOR", "SWE", "RUS"],
+		"networkNeighbors": [],
 		"area": 338424
 	},
 	{
@@ -3430,6 +3502,7 @@
 		"demonym": "Fijian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 18272
 	},
 	{
@@ -3473,6 +3546,7 @@
 		"demonym": "Falkland Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 12173
 	},
 	{
@@ -3516,6 +3590,7 @@
 		"demonym": "French",
 		"landlocked": false,
 		"borders": ["AND", "BEL", "DEU", "ITA", "LUX", "MCO", "ESP", "CHE"],
+		"networkNeighbors": [],
 		"area": 551695
 	},
 	{
@@ -3564,6 +3639,7 @@
 		"demonym": "Faroese",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 1393
 	},
 	{
@@ -3607,6 +3683,7 @@
 		"demonym": "Micronesian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 702
 	},
 	{
@@ -3650,6 +3727,7 @@
 		"demonym": "Gabonese",
 		"landlocked": false,
 		"borders": ["CMR", "COG", "GNQ"],
+		"networkNeighbors": [],
 		"area": 267668
 	},
 	{
@@ -3693,6 +3771,7 @@
 		"demonym": "British",
 		"landlocked": false,
 		"borders": ["IRL"],
+		"networkNeighbors": [],
 		"area": 242900
 	},
 	{
@@ -3736,6 +3815,7 @@
 		"demonym": "Georgian",
 		"landlocked": false,
 		"borders": ["ARM", "AZE", "RUS", "TUR"],
+		"networkNeighbors": [],
 		"area": 69700
 	},
 	{
@@ -3789,6 +3869,7 @@
 		"demonym": "Channel Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 78
 	},
 	{
@@ -3832,6 +3913,7 @@
 		"demonym": "Ghanaian",
 		"landlocked": false,
 		"borders": ["BFA", "CIV", "TGO"],
+		"networkNeighbors": [],
 		"area": 238533
 	},
 	{
@@ -3875,6 +3957,7 @@
 		"demonym": "Gibraltar",
 		"landlocked": false,
 		"borders": ["ESP"],
+		"networkNeighbors": [],
 		"area": 6
 	},
 	{
@@ -3918,6 +4001,7 @@
 		"demonym": "Guinean",
 		"landlocked": false,
 		"borders": ["CIV", "GNB", "LBR", "MLI", "SEN", "SLE"],
+		"networkNeighbors": [],
 		"area": 245857
 	},
 	{
@@ -3961,6 +4045,7 @@
 		"demonym": "Guadeloupian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 1628
 	},
 	{
@@ -4004,6 +4089,7 @@
 		"demonym": "Gambian",
 		"landlocked": false,
 		"borders": ["SEN"],
+		"networkNeighbors": [],
 		"area": 10689
 	},
 	{
@@ -4047,6 +4133,7 @@
 		"demonym": "Guinea-Bissauan",
 		"landlocked": false,
 		"borders": ["GIN", "SEN"],
+		"networkNeighbors": [],
 		"area": 36125
 	},
 	{
@@ -4101,6 +4188,7 @@
 		"demonym": "Equatorial Guinean",
 		"landlocked": false,
 		"borders": ["CMR", "GAB"],
+		"networkNeighbors": [],
 		"area": 28051
 	},
 	{
@@ -4144,6 +4232,7 @@
 		"demonym": "Greek",
 		"landlocked": false,
 		"borders": ["ALB", "BGR", "TUR", "MKD"],
+		"networkNeighbors": [],
 		"area": 131990
 	},
 	{
@@ -4187,6 +4276,7 @@
 		"demonym": "Grenadian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 344
 	},
 	{
@@ -4230,6 +4320,7 @@
 		"demonym": "Greenlandic",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 2166086
 	},
 	{
@@ -4273,6 +4364,7 @@
 		"demonym": "Guatemalan",
 		"landlocked": false,
 		"borders": ["BLZ", "SLV", "HND", "MEX"],
+		"networkNeighbors": [],
 		"area": 108889
 	},
 	{
@@ -4316,6 +4408,7 @@
 		"demonym": "",
 		"landlocked": false,
 		"borders": ["BRA", "SUR"],
+		"networkNeighbors": [],
 		"area": 83534
 	},
 	{
@@ -4369,6 +4462,7 @@
 		"demonym": "Guamanian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 549
 	},
 	{
@@ -4412,6 +4506,7 @@
 		"demonym": "Guyanese",
 		"landlocked": false,
 		"borders": ["BRA", "SUR", "VEN"],
+		"networkNeighbors": [],
 		"area": 214969
 	},
 	{
@@ -4460,6 +4555,7 @@
 		"demonym": "Hong Konger",
 		"landlocked": false,
 		"borders": ["CHN"],
+		"networkNeighbors": [],
 		"area": 1104
 	},
 	{
@@ -4503,6 +4599,7 @@
 		"demonym": "Heard and McDonald Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 412
 	},
 	{
@@ -4546,6 +4643,7 @@
 		"demonym": "Honduran",
 		"landlocked": false,
 		"borders": ["GTM", "SLV", "NIC"],
+		"networkNeighbors": [],
 		"area": 112492
 	},
 	{
@@ -4590,6 +4688,7 @@
 		"demonym": "Croatian",
 		"landlocked": false,
 		"borders": ["BIH", "HUN", "MNE", "SRB", "SVN"],
+		"networkNeighbors": [],
 		"area": 56594
 	},
 	{
@@ -4638,6 +4737,7 @@
 		"demonym": "Haitian",
 		"landlocked": false,
 		"borders": ["DOM"],
+		"networkNeighbors": [],
 		"area": 27750
 	},
 	{
@@ -4681,6 +4781,7 @@
 		"demonym": "Hungarian",
 		"landlocked": true,
 		"borders": ["AUT", "HRV", "ROU", "SRB", "SVK", "SVN", "UKR"],
+		"networkNeighbors": [],
 		"area": 93028
 	},
 	{
@@ -4724,6 +4825,7 @@
 		"demonym": "Indonesian",
 		"landlocked": false,
 		"borders": ["TLS", "MYS", "PNG"],
+		"networkNeighbors": [],
 		"area": 1904569
 	},
 	{
@@ -4772,6 +4874,7 @@
 		"demonym": "Manx",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 572
 	},
 	{
@@ -4825,6 +4928,7 @@
 		"demonym": "Indian",
 		"landlocked": false,
 		"borders": ["AFG", "BGD", "BTN", "MMR", "CHN", "NPL", "PAK", "LKA"],
+		"networkNeighbors": [],
 		"area": 3287590
 	},
 	{
@@ -4869,6 +4973,7 @@
 		"demonym": "Indian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 60
 	},
 	{
@@ -4917,6 +5022,7 @@
 		"demonym": "Irish",
 		"landlocked": false,
 		"borders": ["GBR"],
+		"networkNeighbors": [],
 		"area": 70273
 	},
 	{
@@ -4959,6 +5065,7 @@
 		"demonym": "Iranian",
 		"landlocked": false,
 		"borders": ["AFG", "ARM", "AZE", "IRQ", "PAK", "TUR", "TKM"],
+		"networkNeighbors": [],
 		"area": 1648195
 	},
 	{
@@ -5012,6 +5119,7 @@
 		"demonym": "Iraqi",
 		"landlocked": false,
 		"borders": ["IRN", "JOR", "KWT", "SAU", "SYR", "TUR"],
+		"networkNeighbors": [],
 		"area": 438317
 	},
 	{
@@ -5055,6 +5163,7 @@
 		"demonym": "Icelander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 103000
 	},
 	{
@@ -5103,6 +5212,7 @@
 		"demonym": "Israeli",
 		"landlocked": false,
 		"borders": ["EGY", "JOR", "LBN", "SYR"],
+		"networkNeighbors": ["ITA", "FRA", "ESP"],
 		"area": 20770
 	},
 	{
@@ -5156,6 +5266,7 @@
 		"demonym": "Italian",
 		"landlocked": false,
 		"borders": ["AUT", "FRA", "SMR", "SVN", "CHE", "VAT"],
+		"networkNeighbors": [],
 		"area": 301336
 	},
 	{
@@ -5204,6 +5315,7 @@
 		"demonym": "Jamaican",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 10991
 	},
 	{
@@ -5257,6 +5369,7 @@
 		"demonym": "Channel Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 116
 	},
 	{
@@ -5300,6 +5413,7 @@
 		"demonym": "Jordanian",
 		"landlocked": false,
 		"borders": ["IRQ", "ISR", "SAU", "SYR"],
+		"networkNeighbors": [],
 		"area": 89342
 	},
 	{
@@ -5343,6 +5457,7 @@
 		"demonym": "Japanese",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 377930
 	},
 	{
@@ -5391,6 +5506,7 @@
 		"demonym": "Kazakhstani",
 		"landlocked": true,
 		"borders": ["CHN", "KGZ", "RUS", "TKM", "UZB"],
+		"networkNeighbors": [],
 		"area": 2724900
 	},
 	{
@@ -5439,6 +5555,7 @@
 		"demonym": "Kenyan",
 		"landlocked": false,
 		"borders": ["ETH", "SOM", "SSD", "TZA", "UGA"],
+		"networkNeighbors": [],
 		"area": 580367
 	},
 	{
@@ -5487,6 +5604,7 @@
 		"demonym": "Kirghiz",
 		"landlocked": true,
 		"borders": ["CHN", "KAZ", "TJK", "UZB"],
+		"networkNeighbors": [],
 		"area": 199951
 	},
 	{
@@ -5531,6 +5649,7 @@
 		"demonym": "Cambodian",
 		"landlocked": false,
 		"borders": ["LAO", "THA", "VNM"],
+		"networkNeighbors": [],
 		"area": 181035
 	},
 	{
@@ -5579,6 +5698,7 @@
 		"demonym": "I-Kiribati",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 811
 	},
 	{
@@ -5622,6 +5742,7 @@
 		"demonym": "Kittitian or Nevisian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 261
 	},
 	{
@@ -5665,6 +5786,7 @@
 		"demonym": "South Korean",
 		"landlocked": false,
 		"borders": ["PRK"],
+		"networkNeighbors": [],
 		"area": 100210
 	},
 	{
@@ -5708,6 +5830,7 @@
 		"demonym": "Kosovar",
 		"landlocked": true,
 		"borders": ["ALB", "MKD", "MNE", "SRB"],
+		"networkNeighbors": [],
 		"area": 10908
 	},
 	{
@@ -5751,6 +5874,7 @@
 		"demonym": "Kuwaiti",
 		"landlocked": false,
 		"borders": ["IRQ", "SAU"],
+		"networkNeighbors": [],
 		"area": 17818
 	},
 	{
@@ -5794,6 +5918,7 @@
 		"demonym": "Laotian",
 		"landlocked": true,
 		"borders": ["MMR", "KHM", "CHN", "THA", "VNM"],
+		"networkNeighbors": [],
 		"area": 236800
 	},
 	{
@@ -5842,6 +5967,7 @@
 		"demonym": "Lebanese",
 		"landlocked": false,
 		"borders": ["ISR", "SYR"],
+		"networkNeighbors": ["ESP", "ITA"],
 		"area": 10452
 	},
 	{
@@ -5885,6 +6011,7 @@
 		"demonym": "Liberian",
 		"landlocked": false,
 		"borders": ["GIN", "CIV", "SLE"],
+		"networkNeighbors": [],
 		"area": 111369
 	},
 	{
@@ -5928,6 +6055,7 @@
 		"demonym": "Libyan",
 		"landlocked": false,
 		"borders": ["DZA", "TCD", "EGY", "NER", "SDN", "TUN"],
+		"networkNeighbors": [],
 		"area": 1759540
 	},
 	{
@@ -5971,6 +6099,7 @@
 		"demonym": "Saint Lucian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 616
 	},
 	{
@@ -6014,6 +6143,7 @@
 		"demonym": "Liechtensteiner",
 		"landlocked": true,
 		"borders": ["AUT", "CHE"],
+		"networkNeighbors": [],
 		"area": 160
 	},
 	{
@@ -6062,6 +6192,7 @@
 		"demonym": "Sri Lankan",
 		"landlocked": false,
 		"borders": ["IND"],
+		"networkNeighbors": [],
 		"area": 65610
 	},
 	{
@@ -6110,6 +6241,7 @@
 		"demonym": "Mosotho",
 		"landlocked": true,
 		"borders": ["ZAF"],
+		"networkNeighbors": [],
 		"area": 30355
 	},
 	{
@@ -6153,6 +6285,7 @@
 		"demonym": "Lithuanian",
 		"landlocked": false,
 		"borders": ["BLR", "LVA", "POL", "RUS"],
+		"networkNeighbors": [],
 		"area": 65300
 	},
 	{
@@ -6206,6 +6339,7 @@
 		"demonym": "Luxembourger",
 		"landlocked": true,
 		"borders": ["BEL", "FRA", "DEU"],
+		"networkNeighbors": [],
 		"area": 2586
 	},
 	{
@@ -6249,6 +6383,7 @@
 		"demonym": "Latvian",
 		"landlocked": false,
 		"borders": ["BLR", "EST", "LTU", "RUS"],
+		"networkNeighbors": [],
 		"area": 64559
 	},
 	{
@@ -6297,6 +6432,7 @@
 		"demonym": "Chinese",
 		"landlocked": false,
 		"borders": ["CHN"],
+		"networkNeighbors": [],
 		"area": 30
 	},
 	{
@@ -6340,6 +6476,7 @@
 		"demonym": "Saint Martin Islander",
 		"landlocked": false,
 		"borders": ["SXM"],
+		"networkNeighbors": [],
 		"area": 53
 	},
 	{
@@ -6388,6 +6525,7 @@
 		"demonym": "Moroccan",
 		"landlocked": false,
 		"borders": ["DZA", "ESH", "ESP"],
+		"networkNeighbors": [],
 		"area": 446550
 	},
 	{
@@ -6431,6 +6569,7 @@
 		"demonym": "Monegasque",
 		"landlocked": false,
 		"borders": ["FRA"],
+		"networkNeighbors": [],
 		"area": 2.02
 	},
 	{
@@ -6474,6 +6613,7 @@
 		"demonym": "Moldovan",
 		"landlocked": true,
 		"borders": ["ROU", "UKR"],
+		"networkNeighbors": [],
 		"area": 33846
 	},
 	{
@@ -6522,6 +6662,7 @@
 		"demonym": "Malagasy",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 587041
 	},
 	{
@@ -6565,6 +6706,7 @@
 		"demonym": "Maldivan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 300
 	},
 	{
@@ -6608,6 +6750,7 @@
 		"demonym": "Mexican",
 		"landlocked": false,
 		"borders": ["BLZ", "GTM", "USA"],
+		"networkNeighbors": [],
 		"area": 1964375
 	},
 	{
@@ -6656,6 +6799,7 @@
 		"demonym": "Marshallese",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 181
 	},
 	{
@@ -6699,6 +6843,7 @@
 		"demonym": "Macedonian",
 		"landlocked": true,
 		"borders": ["ALB", "BGR", "GRC", "KOS", "SRB"],
+		"networkNeighbors": [],
 		"area": 25713
 	},
 	{
@@ -6742,6 +6887,7 @@
 		"demonym": "Malian",
 		"landlocked": true,
 		"borders": ["DZA", "BFA", "GIN", "CIV", "MRT", "NER", "SEN"],
+		"networkNeighbors": [],
 		"area": 1240192
 	},
 	{
@@ -6790,6 +6936,7 @@
 		"demonym": "Maltese",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 316
 	},
 	{
@@ -6833,6 +6980,7 @@
 		"demonym": "Bamar",
 		"landlocked": false,
 		"borders": ["BGD", "CHN", "IND", "LAO", "THA"],
+		"networkNeighbors": [],
 		"area": 676578
 	},
 	{
@@ -6876,6 +7024,7 @@
 		"demonym": "Montenegrin",
 		"landlocked": false,
 		"borders": ["ALB", "BIH", "HRV", "KOS", "SRB"],
+		"networkNeighbors": [],
 		"area": 13812
 	},
 	{
@@ -6919,6 +7068,7 @@
 		"demonym": "Mongolian",
 		"landlocked": true,
 		"borders": ["CHN", "RUS"],
+		"networkNeighbors": [],
 		"area": 1564110
 	},
 	{
@@ -6972,6 +7122,7 @@
 		"demonym": "American",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 464
 	},
 	{
@@ -7015,6 +7166,7 @@
 		"demonym": "Mozambican",
 		"landlocked": false,
 		"borders": ["MWI", "ZAF", "SWZ", "TZA", "ZMB", "ZWE"],
+		"networkNeighbors": [],
 		"area": 801590
 	},
 	{
@@ -7058,6 +7210,7 @@
 		"demonym": "Mauritanian",
 		"landlocked": false,
 		"borders": ["DZA", "MLI", "SEN", "ESH"],
+		"networkNeighbors": [],
 		"area": 1030700
 	},
 	{
@@ -7101,6 +7254,7 @@
 		"demonym": "Montserratian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 102
 	},
 	{
@@ -7144,6 +7298,7 @@
 		"demonym": "French",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 1128
 	},
 	{
@@ -7197,6 +7352,7 @@
 		"demonym": "Mauritian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 2040
 	},
 	{
@@ -7245,6 +7401,7 @@
 		"demonym": "Malawian",
 		"landlocked": true,
 		"borders": ["MOZ", "TZA", "ZMB"],
+		"networkNeighbors": [],
 		"area": 118484
 	},
 	{
@@ -7293,6 +7450,7 @@
 		"demonym": "Malaysian",
 		"landlocked": false,
 		"borders": ["BRN", "IDN", "THA"],
+		"networkNeighbors": [],
 		"area": 330803
 	},
 	{
@@ -7336,6 +7494,7 @@
 		"demonym": "Mahoran",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 374
 	},
 	{
@@ -7419,6 +7578,7 @@
 		"demonym": "Namibian",
 		"landlocked": false,
 		"borders": ["AGO", "BWA", "ZAF", "ZMB"],
+		"networkNeighbors": [],
 		"area": 825615
 	},
 	{
@@ -7462,6 +7622,7 @@
 		"demonym": "New Caledonian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 18575
 	},
 	{
@@ -7505,6 +7666,7 @@
 		"demonym": "Nigerien",
 		"landlocked": true,
 		"borders": ["DZA", "BEN", "BFA", "TCD", "LBY", "MLI", "NGA"],
+		"networkNeighbors": [],
 		"area": 1267000
 	},
 	{
@@ -7553,6 +7715,7 @@
 		"demonym": "Norfolk Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 36
 	},
 	{
@@ -7596,6 +7759,7 @@
 		"demonym": "Nigerian",
 		"landlocked": false,
 		"borders": ["BEN", "CMR", "TCD", "NER"],
+		"networkNeighbors": [],
 		"area": 923768
 	},
 	{
@@ -7639,6 +7803,7 @@
 		"demonym": "Nicaraguan",
 		"landlocked": false,
 		"borders": ["CRI", "HND"],
+		"networkNeighbors": [],
 		"area": 130373
 	},
 	{
@@ -7687,6 +7852,7 @@
 		"demonym": "Niuean",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 260
 	},
 	{
@@ -7730,6 +7896,7 @@
 		"demonym": "Dutch",
 		"landlocked": false,
 		"borders": ["BEL", "DEU"],
+		"networkNeighbors": [],
 		"area": 41850
 	},
 	{
@@ -7783,6 +7950,7 @@
 		"demonym": "Norwegian",
 		"landlocked": false,
 		"borders": ["FIN", "SWE", "RUS"],
+		"networkNeighbors": [],
 		"area": 323802
 	},
 	{
@@ -7826,6 +7994,7 @@
 		"demonym": "Nepalese",
 		"landlocked": true,
 		"borders": ["CHN", "IND"],
+		"networkNeighbors": [],
 		"area": 147181
 	},
 	{
@@ -7874,6 +8043,7 @@
 		"demonym": "Nauruan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 21
 	},
 	{
@@ -7927,6 +8097,7 @@
 		"demonym": "New Zealander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 270467
 	},
 	{
@@ -7970,6 +8141,7 @@
 		"demonym": "Omani",
 		"landlocked": false,
 		"borders": ["SAU", "ARE", "YEM"],
+		"networkNeighbors": [],
 		"area": 309500
 	},
 	{
@@ -8018,6 +8190,7 @@
 		"demonym": "Pakistani",
 		"landlocked": false,
 		"borders": ["AFG", "CHN", "IND", "IRN"],
+		"networkNeighbors": [],
 		"area": 881912
 	},
 	{
@@ -8061,6 +8234,7 @@
 		"demonym": "Panamanian",
 		"landlocked": false,
 		"borders": ["COL", "CRI"],
+		"networkNeighbors": [],
 		"area": 75417
 	},
 	{
@@ -8104,6 +8278,7 @@
 		"demonym": "Pitcairn Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 47
 	},
 	{
@@ -8157,6 +8332,7 @@
 		"demonym": "Peruvian",
 		"landlocked": false,
 		"borders": ["BOL", "BRA", "CHL", "COL", "ECU"],
+		"networkNeighbors": [],
 		"area": 1285216
 	},
 	{
@@ -8205,6 +8381,7 @@
 		"demonym": "Filipino",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 342353
 	},
 	{
@@ -8253,6 +8430,7 @@
 		"demonym": "Palauan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 459
 	},
 	{
@@ -8306,6 +8484,7 @@
 		"demonym": "Papua New Guinean",
 		"landlocked": false,
 		"borders": ["IDN"],
+		"networkNeighbors": [],
 		"area": 462840
 	},
 	{
@@ -8349,6 +8528,7 @@
 		"demonym": "Polish",
 		"landlocked": false,
 		"borders": ["BLR", "CZE", "DEU", "LTU", "RUS", "SVK", "UKR"],
+		"networkNeighbors": [],
 		"area": 312679
 	},
 	{
@@ -8397,6 +8577,7 @@
 		"demonym": "Puerto Rican",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 8870
 	},
 	{
@@ -8440,6 +8621,7 @@
 		"demonym": "North Korean",
 		"landlocked": false,
 		"borders": ["CHN", "KOR", "RUS"],
+		"networkNeighbors": [],
 		"area": 120538
 	},
 	{
@@ -8483,6 +8665,7 @@
 		"demonym": "Portuguese",
 		"landlocked": false,
 		"borders": ["ESP"],
+		"networkNeighbors": [],
 		"area": 92090
 	},
 	{
@@ -8531,6 +8714,7 @@
 		"demonym": "Paraguayan",
 		"landlocked": true,
 		"borders": ["ARG", "BOL", "BRA"],
+		"networkNeighbors": [],
 		"area": 406752
 	},
 	{
@@ -8574,6 +8758,7 @@
 		"demonym": "Palestinian",
 		"landlocked": false,
 		"borders": ["ISR", "EGY", "JOR"],
+		"networkNeighbors": [],
 		"area": 6220
 	},
 	{
@@ -8617,6 +8802,7 @@
 		"demonym": "French Polynesian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 4167
 	},
 	{
@@ -8660,6 +8846,7 @@
 		"demonym": "Qatari",
 		"landlocked": false,
 		"borders": ["SAU"],
+		"networkNeighbors": [],
 		"area": 11586
 	},
 	{
@@ -8703,6 +8890,7 @@
 		"demonym": "French",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 2511
 	},
 	{
@@ -8746,6 +8934,7 @@
 		"demonym": "Romanian",
 		"landlocked": false,
 		"borders": ["BGR", "HUN", "MDA", "SRB", "UKR"],
+		"networkNeighbors": [],
 		"area": 238391
 	},
 	{
@@ -8789,6 +8978,7 @@
 		"demonym": "Russian",
 		"landlocked": false,
 		"borders": ["AZE", "BLR", "CHN", "EST", "FIN", "GEO", "KAZ", "PRK", "LVA", "LTU", "MNG", "NOR", "POL", "UKR"],
+		"networkNeighbors": [],
 		"area": 17098242
 	},
 	{
@@ -8842,6 +9032,7 @@
 		"demonym": "Rwandan",
 		"landlocked": true,
 		"borders": ["BDI", "COD", "TZA", "UGA"],
+		"networkNeighbors": [],
 		"area": 26338
 	},
 	{
@@ -8885,6 +9076,7 @@
 		"demonym": "Saudi Arabian",
 		"landlocked": false,
 		"borders": ["IRQ", "JOR", "KWT", "OMN", "QAT", "ARE", "YEM"],
+		"networkNeighbors": [],
 		"area": 2149690
 	},
 	{
@@ -8933,6 +9125,7 @@
 		"demonym": "Sudanese",
 		"landlocked": false,
 		"borders": ["CAF", "TCD", "EGY", "ERI", "ETH", "LBY", "SSD"],
+		"networkNeighbors": [],
 		"area": 1886068
 	},
 	{
@@ -8976,6 +9169,7 @@
 		"demonym": "Senegalese",
 		"landlocked": false,
 		"borders": ["GMB", "GIN", "GNB", "MLI", "MRT"],
+		"networkNeighbors": [],
 		"area": 196722
 	},
 	{
@@ -9034,6 +9228,7 @@
 		"demonym": "Singaporean",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 710
 	},
 	{
@@ -9077,6 +9272,7 @@
 		"demonym": "South Georgian South Sandwich Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 3903
 	},
 	{
@@ -9120,6 +9316,7 @@
 		"demonym": "Norwegian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": -1
 	},
 	{
@@ -9163,6 +9360,7 @@
 		"demonym": "Solomon Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 28896
 	},
 	{
@@ -9206,6 +9404,7 @@
 		"demonym": "Sierra Leonean",
 		"landlocked": false,
 		"borders": ["GIN", "LBR"],
+		"networkNeighbors": [],
 		"area": 71740
 	},
 	{
@@ -9250,6 +9449,7 @@
 		"demonym": "Salvadoran",
 		"landlocked": false,
 		"borders": ["GTM", "HND"],
+		"networkNeighbors": [],
 		"area": 21041
 	},
 	{
@@ -9293,6 +9493,7 @@
 		"demonym": "Sammarinese",
 		"landlocked": true,
 		"borders": ["ITA"],
+		"networkNeighbors": [],
 		"area": 61
 	},
 	{
@@ -9341,6 +9542,7 @@
 		"demonym": "Somali",
 		"landlocked": false,
 		"borders": ["DJI", "ETH", "KEN"],
+		"networkNeighbors": [],
 		"area": 637657
 	},
 	{
@@ -9384,6 +9586,7 @@
 		"demonym": "French",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 242
 	},
 	{
@@ -9427,6 +9630,7 @@
 		"demonym": "Serbian",
 		"landlocked": true,
 		"borders": ["BIH", "BGR", "HRV", "HUN", "KOS", "MKD", "MNE", "ROU"],
+		"networkNeighbors": [],
 		"area": 88361
 	},
 	{
@@ -9470,6 +9674,7 @@
 		"demonym": "South Sudanese",
 		"landlocked": true,
 		"borders": ["CAF", "COD", "ETH", "KEN", "SDN", "UGA"],
+		"networkNeighbors": [],
 		"area": 619745
 	},
 	{
@@ -9513,6 +9718,7 @@
 		"demonym": "Sao Tomean",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 964
 	},
 	{
@@ -9556,6 +9762,7 @@
 		"demonym": "Surinamer",
 		"landlocked": false,
 		"borders": ["BRA", "GUF", "GUY"],
+		"networkNeighbors": [],
 		"area": 163820
 	},
 	{
@@ -9599,6 +9806,7 @@
 		"demonym": "Slovak",
 		"landlocked": true,
 		"borders": ["AUT", "CZE", "HUN", "POL", "UKR"],
+		"networkNeighbors": [],
 		"area": 49037
 	},
 	{
@@ -9642,6 +9850,7 @@
 		"demonym": "Slovene",
 		"landlocked": false,
 		"borders": ["AUT", "HRV", "ITA", "HUN"],
+		"networkNeighbors": [],
 		"area": 20273
 	},
 	{
@@ -9685,6 +9894,7 @@
 		"demonym": "Swedish",
 		"landlocked": false,
 		"borders": ["FIN", "NOR"],
+		"networkNeighbors": [],
 		"area": 450295
 	},
 	{
@@ -9733,6 +9943,7 @@
 		"demonym": "Swazi",
 		"landlocked": true,
 		"borders": ["MOZ", "ZAF"],
+		"networkNeighbors": [],
 		"area": 17364
 	},
 	{
@@ -9785,6 +9996,7 @@
 		"demonym": "St. Maartener",
 		"landlocked": false,
 		"borders": ["MAF"],
+		"networkNeighbors": [],
 		"area": 34
 	},
 	{
@@ -9838,6 +10050,7 @@
 		"demonym": "Seychellois",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 452
 	},
 	{
@@ -9881,6 +10094,7 @@
 		"demonym": "Syrian",
 		"landlocked": false,
 		"borders": ["IRQ", "ISR", "JOR", "LBN", "TUR"],
+		"networkNeighbors": ["EGY"],
 		"area": 185180
 	},
 	{
@@ -9924,6 +10138,7 @@
 		"demonym": "Turks and Caicos Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 948
 	},
 	{
@@ -9973,6 +10188,7 @@
 		"demonym": "Chadian",
 		"landlocked": true,
 		"borders": ["CMR", "CAF", "LBY", "NER", "NGA", "SSD"],
+		"networkNeighbors": [],
 		"area": 1284000
 	},
 	{
@@ -10016,6 +10232,7 @@
 		"demonym": "Togolese",
 		"landlocked": false,
 		"borders": ["BEN", "BFA", "GHA"],
+		"networkNeighbors": [],
 		"area": 56785
 	},
 	{
@@ -10059,6 +10276,7 @@
 		"demonym": "Thai",
 		"landlocked": false,
 		"borders": ["MMR", "KHM", "LAO", "MYS"],
+		"networkNeighbors": [],
 		"area": 513120
 	},
 	{
@@ -10107,6 +10325,7 @@
 		"demonym": "Tadzhik",
 		"landlocked": true,
 		"borders": ["AFG", "CHN", "KGZ", "UZB"],
+		"networkNeighbors": [],
 		"area": 143100
 	},
 	{
@@ -10160,6 +10379,7 @@
 		"demonym": "Tokelauan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 12
 	},
 	{
@@ -10208,6 +10428,7 @@
 		"demonym": "Turkmen",
 		"landlocked": true,
 		"borders": ["AFG", "IRN", "KAZ", "UZB"],
+		"networkNeighbors": [],
 		"area": 488100
 	},
 	{
@@ -10256,6 +10477,7 @@
 		"demonym": "East Timorese",
 		"landlocked": false,
 		"borders": ["IDN"],
+		"networkNeighbors": [],
 		"area": 14874
 	},
 	{
@@ -10304,6 +10526,7 @@
 		"demonym": "Tongan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 747
 	},
 	{
@@ -10347,6 +10570,7 @@
 		"demonym": "Trinidadian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 5130
 	},
 	{
@@ -10390,6 +10614,7 @@
 		"demonym": "Tunisian",
 		"landlocked": false,
 		"borders": ["DZA", "LBY"],
+		"networkNeighbors": ["FRA", "ITA", "SPA"],
 		"area": 163610
 	},
 	{
@@ -10433,6 +10658,7 @@
 		"demonym": "Turkish",
 		"landlocked": false,
 		"borders": ["ARM", "AZE", "BGR", "GEO", "GRC", "IRN", "IRQ", "SYR"],
+		"networkNeighbors": [],
 		"area": 783562
 	},
 	{
@@ -10481,6 +10707,7 @@
 		"demonym": "Tuvaluan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 26
 	},
 	{
@@ -10524,6 +10751,7 @@
 		"demonym": "Taiwanese",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 36193
 	},
 	{
@@ -10572,6 +10800,7 @@
 		"demonym": "Tanzanian",
 		"landlocked": false,
 		"borders": ["BDI", "COD", "KEN", "MWI", "MOZ", "RWA", "UGA", "ZMB"],
+		"networkNeighbors": [],
 		"area": 945087
 	},
 	{
@@ -10620,6 +10849,7 @@
 		"demonym": "Ugandan",
 		"landlocked": true,
 		"borders": ["COD", "KEN", "RWA", "SSD", "TZA"],
+		"networkNeighbors": [],
 		"area": 241550
 	},
 	{
@@ -10668,6 +10898,7 @@
 		"demonym": "Ukrainian",
 		"landlocked": false,
 		"borders": ["BLR", "HUN", "MDA", "POL", "ROU", "RUS", "SVK"],
+		"networkNeighbors": [],
 		"area": 603500
 	},
 	{
@@ -10711,6 +10942,7 @@
 		"demonym": "American",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 34.2
 	},
 	{
@@ -10754,6 +10986,7 @@
 		"demonym": "Uruguayan",
 		"landlocked": false,
 		"borders": ["ARG", "BRA"],
+		"networkNeighbors": [],
 		"area": 181034
 	},
 	{
@@ -10797,6 +11030,7 @@
 		"demonym": "American",
 		"landlocked": false,
 		"borders": ["CAN", "MEX"],
+		"networkNeighbors": [],
 		"area": 9372610
 	},
 	{
@@ -10845,6 +11079,7 @@
 		"demonym": "Uzbekistani",
 		"landlocked": true,
 		"borders": ["AFG", "KAZ", "KGZ", "TJK", "TKM"],
+		"networkNeighbors": [],
 		"area": 447400
 	},
 	{
@@ -10893,6 +11128,7 @@
 		"demonym": "Italian",
 		"landlocked": true,
 		"borders": ["ITA"],
+		"networkNeighbors": [],
 		"area": 0.44
 	},
 	{
@@ -10936,6 +11172,7 @@
 		"demonym": "Saint Vincentian",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 389
 	},
 	{
@@ -10979,6 +11216,7 @@
 		"demonym": "Venezuelan",
 		"landlocked": false,
 		"borders": ["BRA", "COL", "GUY"],
+		"networkNeighbors": [],
 		"area": 916445
 	},
 	{
@@ -11022,6 +11260,7 @@
 		"demonym": "Virgin Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 151
 	},
 	{
@@ -11065,6 +11304,7 @@
 		"demonym": "Virgin Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 347
 	},
 	{
@@ -11108,6 +11348,7 @@
 		"demonym": "Vietnamese",
 		"landlocked": false,
 		"borders": ["KHM", "CHN", "LAO"],
+		"networkNeighbors": [],
 		"area": 331212
 	},
 	{
@@ -11161,6 +11402,7 @@
 		"demonym": "Ni-Vanuatu",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 12189
 	},
 	{
@@ -11204,6 +11446,7 @@
 		"demonym": "Wallis and Futuna Islander",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 142
 	},
 	{
@@ -11252,6 +11495,7 @@
 		"demonym": "Samoan",
 		"landlocked": false,
 		"borders": [],
+		"networkNeighbors": [],
 		"area": 2842
 	},
 	{
@@ -11295,6 +11539,7 @@
 		"demonym": "Yemeni",
 		"landlocked": false,
 		"borders": ["OMN", "SAU"],
+		"networkNeighbors": [],
 		"area": 527968
 	},
 	{
@@ -11388,6 +11633,7 @@
 		"demonym": "South African",
 		"landlocked": false,
 		"borders": ["BWA", "LSO", "MOZ", "NAM", "SWZ", "ZWE"],
+		"networkNeighbors": [],
 		"area": 1221037
 	},
 	{
@@ -11431,6 +11677,7 @@
 		"demonym": "Zambian",
 		"landlocked": true,
 		"borders": ["AGO", "BWA", "COD", "MWI", "MOZ", "NAM", "TZA", "ZWE"],
+		"networkNeighbors": [],
 		"area": 752612
 	},
 	{
@@ -11544,6 +11791,7 @@
 		"demonym": "Zimbabwean",
 		"landlocked": true,
 		"borders": ["BWA", "MOZ", "ZAF", "ZMB"],
+		"networkNeighbors": [],
 		"area": 390757
 	}
 ]

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -740,6 +740,7 @@ class MirrorSelectionDialog(object):
         self.local_country_code = cur_country_code or os.environ.get('LANG', 'US').split('.')[0].split('_')[-1]  # fallback to LANG location or 'US'
 
         self.bordering_countries = []
+        self.network_neighbors = []
         self.subregion = []
         self.region = []
         self.local_country = self.get_country(self.local_country_code)
@@ -753,10 +754,13 @@ class MirrorSelectionDialog(object):
                         self.region.append(country_code)
                 if country["cca3"] in self.local_country["borders"]:
                     self.bordering_countries.append(country_code)
+                elif country["cca3"] in self.local_country["networkNeighbors"]:
+                    self.network_neighbors.append(country_code)
 
         self.worldwide_mirrors = []
         self.local_mirrors = []
         self.bordering_mirrors = []
+        self.network_neighbors_mirrors = []
         self.subregional_mirrors = []
         self.regional_mirrors = []
         self.official_mirrors = []
@@ -770,6 +774,8 @@ class MirrorSelectionDialog(object):
                 self.local_mirrors.append(mirror)
             elif mirror.country_code in self.bordering_countries:
                 self.bordering_mirrors.append(mirror)
+            elif mirror.country_code in self.network_neighbors:
+                self.network_neighbors_mirrors.append(mirror)
             elif mirror.country_code in self.subregion:
                 self.subregional_mirrors.append(mirror)
             elif mirror.country_code in self.region:
@@ -781,14 +787,11 @@ class MirrorSelectionDialog(object):
 
         self.worldwide_mirrors = sorted(self.worldwide_mirrors, key=lambda x: x.country_code)
         self.bordering_mirrors = sorted(self.bordering_mirrors, key=lambda x: x.country_code)
+        self.network_neighbors_mirrors = sorted(self.network_neighbors_mirrors, key=lambda x: x.country_code)
         self.subregional_mirrors = sorted(self.subregional_mirrors, key=lambda x: x.country_code)
         self.regional_mirrors = sorted(self.regional_mirrors, key=lambda x: x.country_code)
 
-        self.visible_mirrors = self.worldwide_mirrors + self.local_mirrors + self.bordering_mirrors + self.subregional_mirrors + self.regional_mirrors + self.official_mirrors
-
-        if self.local_country_code in ["IL"]:
-            # For some countries, geographical proximity doesn't equate to faster mirrors.
-            self.visible_mirrors = self.visible_mirrors + self.other_mirrors
+        self.visible_mirrors = self.worldwide_mirrors + self.local_mirrors + self.bordering_mirrors + self.network_neighbors_mirrors + self.subregional_mirrors + self.regional_mirrors + self.official_mirrors
 
         if len(self.visible_mirrors) < 2:
             # We failed to identify the continent/country, let's show all mirrors


### PR DESCRIPTION
Add config for countries that are close to each other from network point
of view.
Use this information when computing what mirror to suggest
Remove the hard coded Israel exception and use networkNeighbors to add
mirror from country easily reachable

Reason:
Some countries has better network link to countries in other regions
for example north African countries are better connected to southern
Europe (<1000 km Mediterranean sea) than to the rest of Africa (due to
Sahara separating them from other African countries)