### PR TITLE
Don't Prompt User to Refresh APT Cache when Cancelling a Mirror Change

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -1682,17 +1682,17 @@ class Application(object):
 
     def select_new_mirror(self, widget):
         url = self.mirror_selection_dialog.run(self.mirrors, self.config, False)
-        if url is not None:
+        if url is not None and self.selected_mirror != url:
             self.selected_mirror = url
             self.builder.get_object("label_mirror_name").set_text(self.selected_mirror)
-        self.apply_official_sources()
+            self.apply_official_sources()
 
     def select_new_base_mirror(self, widget):
         url = self.mirror_selection_dialog.run(self.base_mirrors, self.config, True)
-        if url is not None:
+        if url is not None and self.selected_base_mirror != url:
             self.selected_base_mirror = url
             self.builder.get_object("label_base_mirror_name").set_text(self.selected_base_mirror)
-        self.apply_official_sources()
+            self.apply_official_sources()
 
     def run(self):
         self._main_window.show_all()


### PR DESCRIPTION
When selecting a new mirror (whether for Main or Base), you will always be prompted to update the APT cache, even if the user selected "Cancel" in the mirror selection prompt or if they didn't actually select a different mirror than what they already had. This commit should solve both of these cases, closing #225 .