### PR TITLE
Draft: deb822 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Mintsources
+# Mintsources
 
 This is a software configuration tool, mintsources, allows the user to adjust sofware repositories, select a mirror, include PPAs and do package management tasks.
 

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -657,7 +657,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="ppas_page">
+                      <object class="GtkBox" id="additional_sources_page">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="margin-left">12</property>
@@ -676,7 +676,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="shadow-type">in</property>
                                 <child>
-                                  <object class="GtkTreeView" id="treeview_ppa">
+                                  <object class="GtkTreeView" id="treeview_sources">
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <child internal-child="selection">
@@ -701,7 +701,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="homogeneous">True</property>
                                     <child>
-                                      <object class="GtkButton" id="button_ppa_add">
+                                      <object class="GtkButton" id="button_source_add">
                                         <property name="label" translatable="yes">Add</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
@@ -714,7 +714,7 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkButton" id="button_ppa_edit">
+                                      <object class="GtkButton" id="button_source_edit">
                                         <property name="label" translatable="yes">Edit</property>
                                         <property name="visible">True</property>
                                         <property name="sensitive">False</property>
@@ -728,144 +728,7 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkButton" id="button_ppa_remove">
-                                        <property name="label" translatable="yes">Remove</property>
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="button_ppa_examine">
-                                        <property name="label" translatable="yes">Open</property>
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                    <style>
-                                      <class name="linked"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <style>
-                                  <class name="inline-toolbar"/>
-                                </style>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="name">ppas</property>
-                        <property name="title" translatable="yes">PPAs</property>
-                        <property name="icon-name">package-x-generic-symbolic</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="additional_repositories_page">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
-                        <property name="margin-top">12</property>
-                        <property name="margin-bottom">12</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkScrolledWindow">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="shadow-type">in</property>
-                                <child>
-                                  <object class="GtkTreeView" id="treeview_repository">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <child internal-child="selection">
-                                      <object class="GtkTreeSelection"/>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <child type="center">
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="homogeneous">True</property>
-                                    <child>
-                                      <object class="GtkButton" id="button_repository_add">
-                                        <property name="label" translatable="yes">Add</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="button_repository_edit">
-                                        <property name="label" translatable="yes">Edit</property>
-                                        <property name="visible">True</property>
-                                        <property name="sensitive">False</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="button_repository_remove">
+                                      <object class="GtkButton" id="button_source_remove">
                                         <property name="label" translatable="yes">Remove</property>
                                         <property name="visible">True</property>
                                         <property name="sensitive">False</property>
@@ -911,9 +774,9 @@
                       </object>
                       <packing>
                         <property name="name">additional_repositories</property>
-                        <property name="title" translatable="yes">Additional Repositories</property>
+                        <property name="title" translatable="yes">Other Repositories</property>
                         <property name="icon-name">package-x-generic-symbolic</property>
-                        <property name="position">2</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
@@ -1035,7 +898,7 @@
                         <property name="name">authentication_keys</property>
                         <property name="title" translatable="yes">Authentication Keys</property>
                         <property name="icon-name">dialog-password-symbolic</property>
-                        <property name="position">3</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                     <child>
@@ -1136,7 +999,7 @@
                         <property name="name">maintenance</property>
                         <property name="title" translatable="yes">Maintenance</property>
                         <property name="icon-name">preferences-other-symbolic</property>
-                        <property name="position">4</property>
+                        <property name="position">3</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
Very rough draft of DEB822 support using [pop-os/repolib](https://github.com/pop-os/repolib) (resolves #236).

![image](https://github.com/linuxmint/mintsources/assets/17551908/03727282-2ff6-4b2f-a341-d087cff95c4a)

Best to back up your `sources.list.d/` before running, repolib seems to be pretty eager to write its `X-*` fields back to disk.

I've combined the handling of PPAs and other repositories, since with multiple URIs per source, the distinction between PPAs and other repositories isn't clear cut anymore. I've also grouped sources by file.

Source formats are preserved (DEB822 or traditional lists).

Next steps would be adding back some missing things and finishing support: adding/removing sources, viewing PPA contents, duplicate removal for 822 sources. See the TODO notes scattered about.

Tested with the latest version of repolib (2.2.1), which isn't packaged in Mint.
