### PR TITLE
Time out if IP Geolocation not reachable

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -708,7 +708,7 @@ class MirrorSelectionDialog(object):
         # Try to find out where we're located...
         self.local_country_code = None
         try:
-            lookup = requests.get('https://api.ip2location.io').json()
+            lookup = requests.get('https://api.ip2location.io', timeout=10).json()
             cur_country_code = lookup['country_code']
             if cur_country_code != 'None':
                 self.local_country_code = cur_country_code


### PR DESCRIPTION
Otherwise, the request waits indefinitely, hence the Software Sources window gets frozen. See [the documentation for request timeouts](https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts).

Currently, https://api.ip2location.io is not reachable where I am (it's been a few hours already). I am not sure if this is temporary, or if it's due to my network, but whatever the reason is, the Software Sources window should not get frozen.

I am not sure if this pr should be against the master branch, but it is the only active branch.