### PR TITLE
Add mirror setup assistant

### DIFF
--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -491,6 +491,7 @@ class MirrorAssistant(object):
 
     def apply(self, user_data):
         self.builder.get_object("mirror_assistant_confirm_message").set_visible(False)
+        self.builder.get_object("mirror_assistant_action_buttons").set_visible(False)
         self.builder.get_object("mirror_assistant_updating_message").set_visible(True)
         client = aptkit.client.AptClient()
         transaction = client.update_cache()

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -503,19 +503,12 @@ class MirrorAssistant(object):
         if self.window.get_current_page() == self.PAGE_CHOOSE_MAIN:
             self._init_main_mirrors_task = Gio.Task.new(self.window, Gio.Cancellable(), self._load_main_mirrors_finished, iter)
             self._init_main_mirrors_task.run_in_thread(self._thread_load_main_mirrors)
-        else:
-
 
         if self.window.get_current_page() == self.PAGE_CHOOSE_BASE:
             self._init_base_mirrors_task = Gio.Task.new(self.window, Gio.Cancellable(),
                                                         self._load_base_mirrors_finished, iter)
             self._init_base_mirrors_task.run_in_thread(self._thread_load_base_mirrors)
-        else:
-            try:
-                self._base_mirrors_list._gtask.get_cancellable().cancel()
-                self._base_mirrors_list._mirrors_model.clear()
-            except:
-                pass
+
         #     # model, path = self._main_mirrors_list._treeview.get_selection().get_selected_rows()
         #     # iter = model.get_iter(path[0])
         #     # url = model.get(iter, MirrorSelectionList.MIRROR_URL_COLUMN)[0]

--- a/usr/lib/linuxmint/mintSources/mintSources.py
+++ b/usr/lib/linuxmint/mintSources/mintSources.py
@@ -529,7 +529,6 @@ class MirrorAssistant(object):
             try:
                 iter = model.get_iter(path[0])
                 self._selected_main_url = model.get(iter, MirrorSelectionList.MIRROR_URL_COLUMN)[0]
-                print("Marked " + str(self._selected_main_url) + " as main mirror.")
             except IndexError:
                 pass
         elif self._base_mirrors_list._treeview.get_selection().get_selected_rows() is not None:
@@ -540,7 +539,6 @@ class MirrorAssistant(object):
             try:
                 iter = model.get_iter(path[0])
                 self._selected_base_url = model.get(iter, MirrorSelectionList.MIRROR_URL_COLUMN)[0]
-                print("Marked " + str(self._selected_base_url) + " as base mirror.")
             except IndexError:
                 pass
         else:
@@ -558,7 +556,6 @@ class MirrorAssistant(object):
 
             # Save main mirror selection
             if self._selected_main_url is not None:
-                print("Saving main mirror: " + str(self._selected_main_url))
                 application.selected_mirror = self._selected_main_url
                 application.apply_official_sources()
 
@@ -571,7 +568,6 @@ class MirrorAssistant(object):
 
             # Save base mirror selection
             if self._selected_base_url is not None:
-                print("Saving base mirror: " + str(self._selected_base_url))
                 application.selected_base_mirror = self._selected_base_url
                 application.apply_official_sources()
 

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -1374,9 +1374,6 @@
           </packing>
         </child>
       </object>
-      <packing>
-        <property name="has-padding">False</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
@@ -1459,9 +1456,6 @@
           </packing>
         </child>
       </object>
-      <packing>
-        <property name="has-padding">False</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
@@ -1633,7 +1627,6 @@
       <packing>
         <property name="page-type">confirm</property>
         <property name="complete">True</property>
-        <property name="has-padding">False</property>
       </packing>
     </child>
     <child>

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -1458,45 +1458,163 @@
         <property name="valign">center</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkImage">
+          <object class="GtkBox" id="mirror_assistant_confirm_message">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="pixel-size">120</property>
-            <property name="icon-name">dialog-ok</property>
-            <property name="icon_size">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="pixel-size">120</property>
+                <property name="icon-name">view-refresh</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Mirrors selected.</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="xpad">6</property>
+                <property name="label" translatable="yes">Click Apply to update the APT cache.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="padding">6</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
+          <object class="GtkBox" id="mirror_assistant_error_message">
             <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Mirrors selected.</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-            </attributes>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="xpad">6</property>
+                <property name="label" translatable="yes">There was an error while updating the APT cache.</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="mirror_assistant_error_text">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="xpad">6</property>
+                <property name="label" translatable="yes">Something went wrong.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="padding">6</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
+          <object class="GtkBox" id="mirror_assistant_updating_message">
             <property name="can-focus">False</property>
-            <property name="xpad">6</property>
-            <property name="label" translatable="yes">Click Apply to update the APT cache.</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">center</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkSpinner">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="active">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="xpad">6</property>
+                    <property name="label" translatable="yes">Updating the APT cache...</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkProgressBar" id="mirror_assistant_update_progress">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="padding">6</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -1556,50 +1556,22 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">6</property>
+            <property name="can-focus">True</property>
+            <property name="margin-left">6</property>
+            <property name="margin-right">6</property>
+            <property name="margin-top">6</property>
+            <property name="hscrollbar-policy">never</property>
+            <property name="shadow-type">in</property>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="xpad">6</property>
-                <property name="label" translatable="yes">Select a mirror from the list below. The list is sorted by speed, with the fastest mirrors at the top.</property>
-                <property name="wrap">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">6</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow">
+              <object class="GtkTreeView" id="mirrors_treeview">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
-                <property name="margin-top">6</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="shadow-type">in</property>
-                <child>
-                  <object class="GtkTreeView" id="mirrors_treeview">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection"/>
-                    </child>
-                  </object>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -1342,6 +1342,9 @@
                   <object class="GtkTreeView" id="mirrors_treeview_main">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -1371,6 +1374,9 @@
           </packing>
         </child>
       </object>
+      <packing>
+        <property name="has-padding">False</property>
+      </packing>
     </child>
     <child>
       <object class="GtkBox">
@@ -1421,6 +1427,9 @@
                   <object class="GtkTreeView" id="mirrors_treeview_base">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -1450,6 +1459,9 @@
           </packing>
         </child>
       </object>
+      <packing>
+        <property name="has-padding">False</property>
+      </packing>
     </child>
     <child>
       <object class="GtkBox">
@@ -1649,7 +1661,7 @@
       <placeholder/>
     </child>
     <child internal-child="action_area">
-      <object class="GtkBox">
+      <object class="GtkBox" id="mirror_assistant_action_buttons">
         <property name="can-focus">False</property>
         <property name="halign">end</property>
         <property name="margin-left">6</property>

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -1328,20 +1328,40 @@
           </packing>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="margin-top">6</property>
-            <property name="hscrollbar-policy">never</property>
-            <property name="shadow-type">in</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkTreeView" id="mirrors_treeview_main">
-                <property name="visible">True</property>
+              <object class="GtkScrolledWindow">
                 <property name="can-focus">True</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
+                <property name="margin-top">6</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="shadow-type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="mirrors_treeview_main">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                  </object>
                 </child>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinner" id="mirrors_main_spinner">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="active">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
@@ -1387,20 +1407,40 @@
           </packing>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="margin-top">6</property>
-            <property name="hscrollbar-policy">never</property>
-            <property name="shadow-type">in</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkTreeView" id="mirrors_treeview_base">
-                <property name="visible">True</property>
+              <object class="GtkScrolledWindow">
                 <property name="can-focus">True</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
+                <property name="margin-top">6</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="shadow-type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="mirrors_treeview_base">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                  </object>
                 </child>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinner" id="mirrors_base_spinner">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="active">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
@@ -1559,7 +1599,6 @@
           <object class="GtkScrolledWindow">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
-            <property name="margin-left">6</property>
             <property name="margin-right">6</property>
             <property name="margin-top">6</property>
             <property name="hscrollbar-policy">never</property>

--- a/usr/lib/linuxmint/mintSources/mintsources.glade
+++ b/usr/lib/linuxmint/mintSources/mintsources.glade
@@ -1287,6 +1287,226 @@
       </object>
     </child>
   </object>
+  <object class="GtkAssistant" id="mirror_assistant">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Mirror Assistant</property>
+    <property name="resizable">False</property>
+    <property name="default-width">580</property>
+    <property name="default-height">480</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Select A Main Mirror</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.1000000000000001"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Select a main download mirror from the list below. The list is sorted by speed, with the fastest mirrors at the top.</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="margin-top">6</property>
+            <property name="hscrollbar-policy">never</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkTreeView" id="mirrors_treeview_main">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Select A Base Mirror</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.1000000000000001"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Select a base download mirror from the list below. The list is sorted by speed, with the fastest mirrors at the top.</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="margin-top">6</property>
+            <property name="hscrollbar-policy">never</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkTreeView" id="mirrors_treeview_base">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="valign">center</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="pixel-size">120</property>
+            <property name="icon-name">dialog-ok</property>
+            <property name="icon_size">6</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Mirrors selected.</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="xpad">6</property>
+            <property name="label" translatable="yes">Click Apply to update the APT cache.</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="page-type">confirm</property>
+        <property name="complete">True</property>
+        <property name="has-padding">False</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="action_area">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="halign">end</property>
+        <property name="margin-left">6</property>
+        <property name="margin-right">6</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
+        <property name="spacing">6</property>
+      </object>
+      <packing>
+        <property name="has-padding">False</property>
+      </packing>
+    </child>
+  </object>
   <object class="GtkDialog" id="mirror_selection_dialog">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Select Mirror</property>
@@ -1336,22 +1556,50 @@
           </packing>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="margin-left">6</property>
-            <property name="margin-right">6</property>
-            <property name="margin-top">6</property>
-            <property name="hscrollbar-policy">never</property>
-            <property name="shadow-type">in</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
             <child>
-              <object class="GtkTreeView" id="mirrors_treeview">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="xpad">6</property>
+                <property name="label" translatable="yes">Select a mirror from the list below. The list is sorted by speed, with the fastest mirrors at the top.</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">6</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection"/>
+                <property name="margin-left">6</property>
+                <property name="margin-right">6</property>
+                <property name="margin-top">6</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="shadow-type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="mirrors_treeview">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
+                  </object>
                 </child>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>


### PR DESCRIPTION
This pull request adds a subcommand `mintsources setup` that opens an assistant that guides the user through selecting software mirrors.

When Linux Mint is first installed, the Update Manager displays a banner suggesting that the user switch from the default upload mirrors. If the user chooses to do so and clicks the button in the prompt, they are brought to Software Sources without any further guidance or instruction, which may be confusing for some new users.

The Mirror Assistant guides the user through the process of selecting mirror servers. The first screen presents the user with a list of Mint sources like the Mirror Selection Dialog where mirrors are listed and ranked by speed. The second screen displays the same for the Ubuntu mirrors. The final screen allows the user to reload the APT cache to apply the changes. After the changes are applied, the app quits automatically.

![2025-07-07_19-43](https://github.com/user-attachments/assets/88d431d1-345e-467b-b556-c7c720ca19a7)

![2025-07-07_19-44_1](https://github.com/user-attachments/assets/04f5c715-deb8-4786-80e7-849f64b7f13f)

![2025-07-07_19-44_2](https://github.com/user-attachments/assets/647d5455-10b4-4df3-9e2d-5aa7cbad5eda)

![2025-07-07_19-44_3](https://github.com/user-attachments/assets/6d25a03e-9bd6-4152-9f86-312f6629c2fc)
