### PR TITLE
Update mintsources.conf: Fix ubuntu.mirrors file name for resolute base

### DIFF
--- a/usr/share/mintsources/alfa/mintsources.conf
+++ b/usr/share/mintsources/alfa/mintsources.conf
@@ -8,7 +8,7 @@ use_ppas=true
 default=http://packages.linuxmint.com
 base_default=http://archive.ubuntu.com/ubuntu
 mirrors=/usr/share/mint-mirrors/linuxmint.list
-base_mirrors=/usr/share/python-apt/templates/Ubuntu.mirrors
+base_mirrors=/usr/share/python-apt/templates/ubuntu.mirrors
 
 [optional_component_1]
 name=romeo


### PR DESCRIPTION
Ubuntu.mirrors file name changed to ubuntu.mirrors on resolute base.

------------

`Traceback (most recent call last):
  File "/usr/lib/linuxmint/mintSources/mintSources.py", line 1917, in <module>
    Application(os_codename).run()
    ~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/linuxmint/mintSources/mintSources.py", line 897, in __init__
    self.base_mirrors = self.read_mirror_list(self.config["mirrors"]["base_mirrors"])
                        ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/linuxmint/mintSources/mintSources.py", line 1058, in read_mirror_list
    mirrorsfile = open(path, "r", encoding="utf-8", errors="ignore")
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/python-apt/templates/Ubuntu.mirrors'
`

```
ls /usr/share/python-apt/templates/
LMDE.mirrors       blankon.mirrors  gnewsense.mirrors  ubuntu.mirrors
LinuxMint.info     debian.info      kali.info
LinuxMint.mirrors  debian.mirrors   kali.mirrors
blankon.info       gnewsense.info   ubuntu.info
```